### PR TITLE
build: change name to `feeze_0.001dev_Ubuntu_24` not `feeze_Ubuntu_24_0.001dev`

### DIFF
--- a/.github/workflows/release_ubuntu_24.yml
+++ b/.github/workflows/release_ubuntu_24.yml
@@ -86,14 +86,20 @@ jobs:
     - name: Read VERSION file
       id: getversion
       run: |
-        echo "version=$(make show_platform_and_version)" >> $GITHUB_OUTPUT
+        version="$(make show_version_and_platform)"
+        echo "version=$version" >> $GITHUB_OUTPUT
+        if (echo $version | grep dev); then
+          echo "prerelease=true" >> $GITHUB_OUTPUT
+        else
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: publish release
       uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
       with:
         artifacts: "feeze_${{ steps.getversion.outputs.version }}.tar.gz"
-        tag: "v${{ steps.getversion.outputs.version }}"
-        prerelease: false
+        tag: "feeze_${{ steps.getversion.outputs.version }}"
+        prerelease: ${{ steps.getversion.outputs.prerelease }}"
         generateReleaseNotes: false
         immutableCreate: true
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ FEEZE_SRC_JAVA := $(FEEZE_SRC)/java
 
 VERSION = $(shell cat $(FEEZE_REPO)/version.txt)
 PLATFORM = $(shell grep PRETTY_NAME /etc/os-release | sed -E 's-.*"([^.]*)\..*-\1-g' | sed s-\ -_-g)
-PLATFORM_AND_VERSION = $(PLATFORM)_$(VERSION)
+VERSION_AND_PLATFORM = $(VERSION)_$(PLATFORM)
 
 # the build directory is relative to the current dir
 BUILD_DIR     := ./build
@@ -67,9 +67,9 @@ JAVA_MAIN_CLASS     := dev.flang.feeze.$(JAVA_MAIN)
 .DELETE_ON_ERROR:
 
 # build all binaries
-.PHONY: show_platform_and_version
-show_platform_and_version:
-	@echo $(PLATFORM_AND_VERSION)
+.PHONY: show_version_and_platform
+show_version_and_platform:
+	@echo $(VERSION_AND_PLATFORM)
 
 all: $(BUILD_DIR)/bin/feeze $(BUILD_DIR)/bin/$(RECORDER_BIN)
 
@@ -214,5 +214,5 @@ clean:
 
 .PHONY: release
 release: clean all
-	rm -f feeze_$(PLATFORM_AND_VERSION).tar.gz
-	tar cfz feeze_$(PLATFORM_AND_VERSION).tar.gz --transform s/^build/feeze_$(PLATFORM_AND_VERSION)/ build/bin build/classes build/libbpf build/libbpf_obj build/icon.svg
+	rm -f feeze_$(VERSION_AND_PLATFORM).tar.gz
+	tar cfz feeze_$(VERSION_AND_PLATFORM).tar.gz --transform s/^build/feeze_$(PLATFORM_AND_VERSION)/ build/bin build/classes build/libbpf build/libbpf_obj build/icon.svg


### PR DESCRIPTION
change tag to `feeze_0.001dev_Ubuntu_24` instead of `v_Ubuntu_24_0.001dev`.  Set preprelease flag for `dev` versions.
