### PR TITLE
rec: do not attempt to load `libfuzion_rt.so` if it does not exist

### DIFF
--- a/src/c/feeze_record.c
+++ b/src/c/feeze_record.c
@@ -859,7 +859,7 @@ void feeze_record(const char* lib_fuzion,
       goto cleanup;
     }
 
-  if (lib_fuzion != NULL)
+  if (lib_fuzion != NULL && lib_fuzion[0] != 0)
     {
       skel->links.handle_fuzion_probe = bpf_program__attach_usdt(skel->progs.handle_fuzion_probe, -1 /* env.pid */,
                                                                  lib_fuzion, "fuzion", "probe", NULL);

--- a/src/fuzion/feeze_recorder.fz
+++ b/src/fuzion/feeze_recorder.fz
@@ -93,7 +93,9 @@ get_option(s String, desired String, action String->unit)
 #
 record ! options =>
   lm ! ()->
-    l := options.env.lib_fuzion.as_c_string lm
+    lf := options.env.lib_fuzion
+    l := (if io.file.exists (io.path.of lf) then lf
+                                            else "\0").as_c_string lm
     s := options.env.shmem_name.as_c_string lm
     feeze_record l options.env.shmem_size s
 


### PR DESCRIPTION
This suppresses BPF internal error output if libfuzion_rt.so does not exist.