### PR TITLE
bin/feeze: allow HiDPI auto-detection instead of forcing uiScale=1.0

### DIFF
--- a/bin/feeze
+++ b/bin/feeze
@@ -103,7 +103,7 @@ fi
 # On some systems, swing does not seem to automatically get the correct system font size.
 # As a workaround, set this factor to get a larger default font.
 #
-: "${UI_SCALE=}"
+: "${UI_SCALE=}"   # make sure $UI_SCALE is defined to avoid error
 
 # shellcheck disable=SC2086
 $FEEZE_JAVA \

--- a/bin/feeze
+++ b/bin/feeze
@@ -103,7 +103,7 @@ fi
 # On some systems, swing does not seem to automatically get the correct system font size.
 # As a workaround, set this factor to get a larger default font.
 #
-UI_SCALE=1.0
+: "${UI_SCALE=}"
 
 # shellcheck disable=SC2086
 $FEEZE_JAVA \
@@ -113,7 +113,7 @@ $FEEZE_JAVA \
   -Dfile.encoding=UTF-8 \
   -Dfeeze.home="$FEEZE_HOME" \
   -Dfeeze.command="$FEEZE_CMD" \
-  -Dsun.java2d.uiScale=$UI_SCALE \
+  ${UI_SCALE:+-Dsun.java2d.uiScale=$UI_SCALE} \
   -p "${FEEZE_HOME}" \
   -m @MAIN_CLASS@ \
   "$@"


### PR DESCRIPTION
`bin/feeze` always passed `-Dsun.java2d.uiScale=1.0`, which overrode
Java's automatic HiDPI detection and pinned the UI to 1x on every system —
making fonts and Swing elements too small on HiDPI displays (the case the
README's "fonts too small" workaround addresses).

Now the flag is only passed when `UI_SCALE` is explicitly set:
- unset (new default): flag omitted → Java auto-detects the display scale
- set (e.g. `UI_SCALE=2.0`): unchanged, value still forced

Tested on Ubuntu 26.04 (HiDPI): GUI now scales correctly by default;
`UI_SCALE=2.0` still forces 2x as before.