### PR TITLE
ci: build .deb, .rpm and a slim tar.gz for each release

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,69 @@
+name: build packages
+
+# Manual trigger for now — an automatic one on release publication can follow
+# once this is known to work.
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to package (e.g. feeze_0.001dev_Ubuntu_24)'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install nfpm
+        run: |
+          # Asset names carry the version (nfpm_2.47.0_Linux_x86_64.tar.gz), so
+          # /latest/download/<name> gives a 404 — ask the API for the real URL.
+          # The API repeats the same asset in several fields, hence head -n1.
+          URL=$(curl -s https://api.github.com/repos/goreleaser/nfpm/releases/latest | grep -o 'https://[^"]*_Linux_x86_64\.tar\.gz' | head -n1)
+          echo "nfpm URL=[$URL]"
+          curl -fL -o /tmp/nfpm.tar.gz "$URL"
+          sudo tar zxf /tmp/nfpm.tar.gz -C /usr/local/bin nfpm
+          nfpm --version
+
+      - name: Download and unpack the release tarball
+        run: |
+          TAG="${{ github.event.inputs.release_tag }}"
+          echo "TAG=[$TAG]"
+          # Ask the API for the asset URL instead of constructing it by hand.
+          URL=$(curl -s "https://api.github.com/repos/tokiwa-software/feeze/releases/tags/$TAG" | grep -o 'https://[^"]*\.tar\.gz' | head -n1)
+          echo "URL=[$URL]"
+          test -n "$URL" || { echo "no asset found for tag $TAG"; exit 1; }
+          curl -fL -o release.tar.gz "$URL"
+          tar zxf release.tar.gz
+          ls -la
+
+      - name: Build .deb and .rpm
+        run: |
+          sudo apt-get install -y gettext-base   # provides envsubst
+          TAG="${{ github.event.inputs.release_tag }}"
+          VERSION="$(echo "$TAG" | cut -d_ -f2)"
+          echo "VERSION=[$VERSION]"
+          ./packaging/build-packages.sh "$VERSION" "$TAG"
+
+      - name: Build slim tar.gz
+        run: |
+          TAG="${{ github.event.inputs.release_tag }}"
+          VERSION="$(echo "$TAG" | cut -d_ -f2)"
+          OUT="feeze_${VERSION}_amd64"
+          # Same contents as the packages: no libbpf/ or libbpf_obj/, which are
+          # build artifacts and make up ~75% of the upstream tarball.
+          mkdir -p "$OUT"
+          cp -r "$TAG/bin" "$TAG/classes" "$TAG/icon.svg" "$OUT/"
+          tar czf "dist/$OUT.tar.gz" "$OUT"
+          ls -la dist/
+
+      - name: Attach packages to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.inputs.release_tag }}" dist/*.deb dist/*.rpm dist/*.tar.gz --clobber
+          gh release view "${{ github.event.inputs.release_tag }}" --json assets --jq '.assets[].name'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+.vagrant/
+dist/

--- a/packaging/build-packages.sh
+++ b/packaging/build-packages.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Builds .deb and .rpm from an unpacked feeze release tarball.
+#
+#   ./build-packages.sh 0.001dev /path/to/feeze_0.001dev_Ubuntu_24
+#
+set -euo pipefail
+
+export FEEZE_VERSION="${1:?usage: $0 <version> <unpacked-release-dir>}"
+export FEEZE_SRC="$(realpath "${2:?usage: $0 <version> <unpacked-release-dir>}")"
+
+cd "$(dirname "$0")"
+mkdir -p ../dist
+
+# nfpm expands ${...} in scalar fields but not in contents[].src,
+# so render the config first.
+envsubst < nfpm.yaml.tmpl > /tmp/nfpm.rendered.yaml
+
+for pkg in deb rpm; do
+  nfpm pkg --config /tmp/nfpm.rendered.yaml --packager "$pkg" --target ../dist/
+done
+
+ls -la ../dist/

--- a/packaging/nfpm.yaml.tmpl
+++ b/packaging/nfpm.yaml.tmpl
@@ -1,0 +1,42 @@
+# nfpm.yaml — one config, builds both .deb and .rpm
+# docs: https://nfpm.goreleaser.com/configuration/
+name: feeze
+arch: amd64
+platform: linux
+version: ${FEEZE_VERSION}
+maintainer: Tokiwa Software GmbH <info@tokiwa.software>
+description: |
+  Interactive graphical thread and scheduling analysis tool using eBPF.
+vendor: Tokiwa Software GmbH
+homepage: https://github.com/tokiwa-software/feeze
+license: AGPL-3.0
+
+# Same libraries, different package names per distribution family.
+overrides:
+  deb:
+    depends:
+      - openjdk-25-jre | openjdk-25-jdk
+      - libgc1
+  rpm:
+    depends:
+      - java-25-openjdk
+      - gc
+
+contents:
+  - src: ${FEEZE_SRC}/bin
+    dst: /usr/lib/feeze/bin
+  - src: ${FEEZE_SRC}/classes
+    dst: /usr/lib/feeze/classes
+  - src: ${FEEZE_SRC}/icon.svg
+    dst: /usr/lib/feeze/icon.svg
+
+  # libbpf/ and libbpf_obj/ are deliberately excluded: static library,
+  # object files and headers left over from the build. The recorder links
+  # libbpf statically and never references those paths at runtime.
+
+  - src: /usr/lib/feeze/bin/feeze
+    dst: /usr/bin/feeze
+    type: symlink
+  - src: /usr/lib/feeze/bin/feeze_recorder
+    dst: /usr/bin/feeze_recorder
+    type: symlink


### PR DESCRIPTION
Adds a workflow that builds packages (with nfpm) from the published release tarball and attaches them to the release as separate files.

**Size.** Three files totaling ~1.4 MB versus 5.0 MB for the original tarball. The difference lies in the `libbpf/` and `libbpf_obj/` directories (static library, object files, headers). The recorder links libbpf statically and does not access these files at runtime. Perhaps they should be removed from the main tarball as well.
**Question:** There is already a `release_ubuntu_24.yml` file in the repository—perhaps it would be better to integrate the package build as a step within that workflow so they are generated automatically. Let me know what you prefer, and I’ll make the changes.
