### PR TITLE
c: remove inlude `sys/sdt.h`

### DIFF
--- a/.github/workflows/build_ubuntu_24.yml
+++ b/.github/workflows/build_ubuntu_24.yml
@@ -45,9 +45,6 @@ jobs:
         sudo apt-get install linux-tools-`uname -r`
         sudo apt-get install pandoc
 
-        # for DTRACE_PROBE
-        sudo apt-get install systemtap-sdt-dev
-
         echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
         echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/build_ubuntu_26.yml
+++ b/.github/workflows/build_ubuntu_26.yml
@@ -45,9 +45,6 @@ jobs:
         sudo apt-get install linux-tools-`uname -r`
         sudo apt-get install pandoc
 
-        # for DTRACE_PROBE
-        sudo apt-get install systemtap-sdt-dev
-
         echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
         echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/build_ubuntu_latest.yml
+++ b/.github/workflows/build_ubuntu_latest.yml
@@ -45,9 +45,6 @@ jobs:
         sudo apt-get install linux-tools-`uname -r`
         sudo apt-get install pandoc
 
-        # for DTRACE_PROBE
-        sudo apt-get install systemtap-sdt-dev
-
         echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
         echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/release_ubuntu_24.yml
+++ b/.github/workflows/release_ubuntu_24.yml
@@ -47,9 +47,6 @@ jobs:
         sudo apt-get install linux-tools-`uname -r`
         sudo apt-get install pandoc
 
-        # for DTRACE_PROBE
-        sudo apt-get install systemtap-sdt-dev
-
         echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
         echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 

--- a/src/c/feeze_record.c
+++ b/src/c/feeze_record.c
@@ -47,7 +47,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include <pthread.h>
 #include <sys/types.h>
 #include <assert.h>
-#include <sys/sdt.h>
 
 #include "feeze_recorder_common.h"
 #include "feeze_recorder.skel.h"

--- a/src/c/feeze_recorder.c
+++ b/src/c/feeze_recorder.c
@@ -43,7 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include <pthread.h>
 #include <sys/types.h>
 #include <assert.h>
-#include <sys/sdt.h>
 
 #include "feeze_record.h"
 #include "feeze_recorder_common.h"


### PR DESCRIPTION
was used only for debugging of DTRACE_PROBE
