### PR TITLE
gui: suppress output of `ldconfig` when starting feeze gui

### DIFF
--- a/bin/feeze
+++ b/bin/feeze
@@ -86,7 +86,7 @@ if test "$java_version" -lt 25;  then
     exit 1
 fi
 
-if !(ldconfig -p); then
+if !(command -v ldconfig >/dev/null); then
     echo 1>&2 "*** ldconfig not installed, libgc installation detection does not work."
 elif !(ldconfig -p | grep libgc\.so >/dev/null); then
     echo 1>&2 "*** libgc.so not installed."


### PR DESCRIPTION
Don't even run `ldconfig` to check if it exists, but use `command -v` instead with output piped to `/dev/null`.
