### PR TITLE
gui: change curser when hovering over dragabble resize buttons

### DIFF
--- a/src/java/dev/feeze/SchedulingPanorama.java
+++ b/src/java/dev/feeze/SchedulingPanorama.java
@@ -1720,35 +1720,35 @@ class SchedulingPanorama extends Panorama
   }
 
   /**
-   * Component with a dragging area
+   * Component with a resize button
    */
-  public abstract class WithDraggingArea extends JComponent
+  public abstract class WithResizeButton extends JComponent
   {
     /**
-     * Cursor to use when mouse is over drag area
+     * Cursor to use when mouse is over resize button
      */
-    abstract Cursor dragCursor();
+    abstract Cursor resizeCursor();
 
     /**
-     * Drag area is the area where you can grab the line and move it around.
+     * resize button is the area where you can grab the line and move it around.
      */
-    abstract int dragAreaWidth        ();
-    abstract int dragAreaHeight       ();
-    abstract int dragAreaX            ();
-    abstract int dragAreaY            ();
+    abstract int resizeButtonWidth ();
+    abstract int resizeButtonHeight();
+    abstract int resizeButtonX     ();
+    abstract int resizeButtonY     ();
 
 
     /**
-     * Are the given relative (to ThreadNames) coordinates within the drag
+     * Are the given relative (to WithResizeButton) coordinates within the resize
      * button?
      */
-    boolean inDragArea(int x, int y)
+    boolean inResizeButton(int x, int y)
     {
       var ex = x;
       var ey = y;
       return
-        dragAreaX() <= ex && ex < dragAreaX() + dragAreaWidth() &&
-        dragAreaY() <= ey && ey < dragAreaY() + dragAreaHeight();
+        resizeButtonX() <= ex && ex < resizeButtonX() + resizeButtonWidth() &&
+        resizeButtonY() <= ey && ey < resizeButtonY() + resizeButtonHeight();
     }
 
 
@@ -1760,20 +1760,20 @@ class SchedulingPanorama extends Panorama
     }
 
 
-    private boolean _inDragArea = false;
+    private boolean _inResizeButton = false;
 
 
     /**
-     * Are we currently dragging, i.e., changing the width of this component?
+     * Are we currently resizing, i.e., changing the width of this component?
      */
-    boolean _dragging = false;
+    boolean _resizing = false;
 
     /**
-     * During _dragging, the last x/y position of the mouse that was processed to
+     * During _resizing, the last x/y position of the mouse that was processed to
      * change the width.
      */
-    int _dragX = 0;
-    int _dragY = 0;
+    int _resizeX = 0;
+    int _resizeY = 0;
 
     {
       setPreferredSize(new Dimension(1, 1));
@@ -1783,17 +1783,17 @@ class SchedulingPanorama extends Panorama
           @Override
           public void mouseReleased(MouseEvent e)
           {
-            if (e.getComponent() == WithDraggingArea.this &&
+            if (e.getComponent() == WithResizeButton.this &&
                 SwingUtilities.isLeftMouseButton(e))
               {
-                _dragging = false;
+                _resizing = false;
               }
           }
 
           @Override
           public void mouseClicked(MouseEvent e)
           {
-            WithDraggingArea.this.mouseClicked(e);
+            WithResizeButton.this.mouseClicked(e);
           }
 
           @Override
@@ -1809,16 +1809,16 @@ class SchedulingPanorama extends Panorama
           @Override
           public void mousePressed(MouseEvent e)
           {
-            if (e.getComponent() == WithDraggingArea.this &&
+            if (e.getComponent() == WithResizeButton.this &&
                 SwingUtilities.isLeftMouseButton(e))
               {
                 var x = e.getX();
                 var y = e.getY();
-                if (inDragArea(x, y))
+                if (inResizeButton(x, y))
                   {
-                    _dragX = x;
-                    _dragY = y;
-                    _dragging = true;
+                    _resizeX = x;
+                    _resizeY = y;
+                    _resizing = true;
                   }
               }
           }
@@ -1830,15 +1830,15 @@ class SchedulingPanorama extends Panorama
           @Override
           public void mouseMoved(MouseEvent e)
           {
-            if (e.getComponent() == WithDraggingArea.this)
+            if (e.getComponent() == WithResizeButton.this)
               {
                 var x = e.getX();
                 var y = e.getY();
-                var inDragArea = inDragArea(x,y);
-                if (inDragArea != _inDragArea)
+                var inResizeButton = inResizeButton(x,y);
+                if (inResizeButton != _inResizeButton)
                   {
-                    _inDragArea = inDragArea;
-                    setCursor(inDragArea ? dragCursor()
+                    _inResizeButton = inResizeButton;
+                    setCursor(inResizeButton ? resizeCursor()
                                          : Cursor.getDefaultCursor());
                   }
               }
@@ -1847,12 +1847,12 @@ class SchedulingPanorama extends Panorama
           @Override
           public void mouseDragged(MouseEvent e)
           {
-            if (e.getComponent() == WithDraggingArea.this &&
+            if (e.getComponent() == WithResizeButton.this &&
                 SwingUtilities.isLeftMouseButton(e) &&
-                _dragging)
+                _resizing)
               {
-                var dx = e.getX() - _dragX;
-                var dy = e.getY() - _dragY;
+                var dx = e.getX() - _resizeX;
+                var dy = e.getY() - _resizeY;
                 if (dx != 0 || dy != 0)
                   {
                     if (dx > 0)
@@ -1863,8 +1863,8 @@ class SchedulingPanorama extends Panorama
                       {
                         dy = Math.min(dy, SchedulingPanorama.this.getVisibleRect().height - MIN_PANORAMA_HEIGHT());
                       }
-                    _dragX += dx;
-                    _dragY += dy;
+                    _resizeX += dx;
+                    _resizeY += dy;
                     if (e.getComponent() != _topRuler)
                       {
                         _leftRuler.changeWidth( dx);
@@ -1887,29 +1887,29 @@ class SchedulingPanorama extends Panorama
   /**
    * Component to draw scala as top ruler.
    */
-  public class Scala extends WithDraggingArea
+  public class Scala extends WithResizeButton
   {
 
     int _preferredHeight;
 
     /**
      * Minimun height of Scale area, used to make sure it does not
-     * accidentally disappear when dragging.
+     * accidentally disappear when resizing.
      */
     int MIN_SCALA_HEIGHT() { return (int) (4*gapEighth()); }
 
     /**
-     * Cursor to use when mouse is over drag area
+     * Cursor to use when mouse is over resize button
      */
-    Cursor dragCursor() { return Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR); };
+    Cursor resizeCursor() { return Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR); };
 
     /**
-     * Drag area is the area where you can grab the line and move it around.
+     * resize button is the area where you can grab the line and move it around.
      */
-    int dragAreaWidth        () { return (int) (16*gapEighth()); }
-    int dragAreaHeight       () { return (int) (4*gapEighth()); }
-    int dragAreaX            () { return (int) (getVisibleRect().x + getVisibleRect().width  - 24*gapEighth()); }
-    int dragAreaY            () { return (int) (getVisibleRect().y + getVisibleRect().height - dragAreaHeight()); }
+    int resizeButtonWidth () { return (int) (16*gapEighth()); }
+    int resizeButtonHeight() { return (int) (4*gapEighth()); }
+    int resizeButtonX     () { return (int) (getVisibleRect().x + getVisibleRect().width  - 24*gapEighth()); }
+    int resizeButtonY     () { return (int) (getVisibleRect().y + getVisibleRect().height - resizeButtonHeight()); }
 
     {
       setPreferredSize(new Dimension(1, _zoom.STANDARD_FONT_SIZE*7/8*5+16));
@@ -1934,10 +1934,10 @@ class SchedulingPanorama extends Panorama
                                         false);
 
       _zoom.drawFilledRect(g,Color.gray, Color.white, 1,
-                           dragAreaX(),
-                           dragAreaY(),
-                           dragAreaWidth(),
-                           dragAreaHeight());
+                           resizeButtonX(),
+                           resizeButtonY(),
+                           resizeButtonWidth(),
+                           resizeButtonHeight());
     }
   }
 
@@ -1960,27 +1960,27 @@ class SchedulingPanorama extends Panorama
   /**
    * Component to draw thread names as left ruler.
    */
-  public class ThreadNames extends WithDraggingArea
+  public class ThreadNames extends WithResizeButton
   {
 
     /**
      * Minimun width of ThreadNames area, used to make sure it does not
-     * accidentally disappear when dragging.
+     * accidentally disappear when resizing.
      */
     int MIN_THREADNAMES_WIDTH() { return (int) (4*gapEighth()); }
 
     /**
-     * Cursor to use when mouse is over drag area
+     * Cursor to use when mouse is over resize button
      */
-    Cursor dragCursor() { return Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR); };
+    Cursor resizeCursor() { return Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR); };
 
     /**
-     * Drag area is the area where you can grab the line and move it around.
+     * resize button is the area where you can grab the line and move it around.
      */
-    int dragAreaWidth        () { return (int) (4*gapEighth()); }
-    int dragAreaHeight       () { return (int) (16*gapEighth()); }
-    int dragAreaX            () { return (int) (getVisibleRect().x + getVisibleRect().width  - dragAreaWidth()); }
-    int dragAreaY            () { return (int) (getVisibleRect().y + getVisibleRect().height - 24*gapEighth() ); }
+    int resizeButtonWidth () { return (int) (4*gapEighth()); }
+    int resizeButtonHeight() { return (int) (16*gapEighth()); }
+    int resizeButtonX     () { return (int) (getVisibleRect().x + getVisibleRect().width  - resizeButtonWidth()); }
+    int resizeButtonY     () { return (int) (getVisibleRect().y + getVisibleRect().height - 24*gapEighth() ); }
 
     {
       setPreferredSize(new Dimension(_zoom.STANDARD_FONT_SIZE*10, 1));
@@ -1994,7 +1994,7 @@ class SchedulingPanorama extends Panorama
       var c = e.getComponent();
       if (x >= 0 && x < c.getWidth() &&
           y >= 0 && y < c.getHeight() &&
-          !inDragArea(x, y))
+          !inResizeButton(x, y))
         {
           if (y >= cpusY() && y < cpusYHeaderBottom())
             {
@@ -2149,10 +2149,10 @@ class SchedulingPanorama extends Panorama
                      getWidth()-1, 0,
                      getWidth()-1, getHeight()-1);
       _zoom.drawFilledRect(g,Color.gray, Color.white, 1,
-                           dragAreaX(),
-                           dragAreaY(),
-                           dragAreaWidth(),
-                           dragAreaHeight());
+                           resizeButtonX(),
+                           resizeButtonY(),
+                           resizeButtonWidth(),
+                           resizeButtonHeight());
     }
   }
 
@@ -2207,33 +2207,33 @@ class SchedulingPanorama extends Panorama
   /**
    * Component to draw top left area
    */
-  class TopLeft extends WithDraggingArea
+  class TopLeft extends WithResizeButton
   {
 
     /**
      * Minimun width of topLeft area, used to make sure it does not accidentally
-     * disappear when dragging.
+     * disappear when resizing.
      */
     int MIN_WIDTH() { return (int) (8*gapEighth()); }
 
     /**
      * Minimun height of topLeft area, used to make sure it does not accidentally
-     * disappear when dragging.
+     * disappear when resizing.
      */
     int MIN_HEIGHT() { return (int) (8*gapEighth()); }
 
     /**
-     * Cursor to use when mouse is over drag area
+     * Cursor to use when mouse is over resize button
      */
-    Cursor dragCursor() { return Cursor.getPredefinedCursor(Cursor.NW_RESIZE_CURSOR); };
+    Cursor resizeCursor() { return Cursor.getPredefinedCursor(Cursor.NW_RESIZE_CURSOR); };
 
     /**
-     * Drag area is the area where you can grab the line and move it around.
+     * resize button is the area where you can grab the line and move it around.
      */
-    int dragAreaWidth        () { return (int) (8*gapEighth()); }
-    int dragAreaHeight       () { return (int) (8*gapEighth()); }
-    int dragAreaX            () { return (int) (getWidth()  - dragAreaWidth() ); }
-    int dragAreaY            () { return (int) (getHeight() - dragAreaHeight()); }
+    int resizeButtonWidth () { return (int) (8*gapEighth()); }
+    int resizeButtonHeight() { return (int) (8*gapEighth()); }
+    int resizeButtonX     () { return (int) (getWidth()  - resizeButtonWidth() ); }
+    int resizeButtonY     () { return (int) (getHeight() - resizeButtonHeight()); }
 
 
     protected void paintComponent(Graphics g)
@@ -2249,26 +2249,26 @@ class SchedulingPanorama extends Panorama
                      v.x+v.width-1, v.y,
                      v.x+v.width-1, v.y+v.height-1);
       _zoom.drawFilledRect(g,Color.gray, Color.white, 1,
-                           dragAreaX(),
-                           dragAreaY(),
-                           dragAreaWidth(),
-                           dragAreaHeight());
+                           resizeButtonX(),
+                           resizeButtonY(),
+                           resizeButtonWidth(),
+                           resizeButtonHeight());
       g.setColor(Color.gray);
       _zoom.drawLine(g, 1,
-                     (int) (dragAreaX()+                  2*gapEighth()), (int) (dragAreaY()+                  2*gapEighth()),
-                     (int) (dragAreaX()+                  4*gapEighth()), (int) (dragAreaY()+                  2*gapEighth()));
+                     (int) (resizeButtonX()+                      2*gapEighth()), (int) (resizeButtonY()+                       2*gapEighth()),
+                     (int) (resizeButtonX()+                      4*gapEighth()), (int) (resizeButtonY()+                       2*gapEighth()));
       _zoom.drawLine(g, 1,
-                     (int) (dragAreaX()+                  2*gapEighth()), (int) (dragAreaY()+                  2*gapEighth()),
-                     (int) (dragAreaX()+                  2*gapEighth()), (int) (dragAreaY()+                  4*gapEighth()));
+                     (int) (resizeButtonX()+                      2*gapEighth()), (int) (resizeButtonY()+                       2*gapEighth()),
+                     (int) (resizeButtonX()+                      2*gapEighth()), (int) (resizeButtonY()+                       4*gapEighth()));
       _zoom.drawLine(g, 1,
-                     (int) (dragAreaX()+dragAreaWidth()-1-2*gapEighth()), (int) (dragAreaY()+dragAreaHeight()-1-2*gapEighth()),
-                     (int) (dragAreaX()+dragAreaWidth()-1-4*gapEighth()), (int) (dragAreaY()+dragAreaHeight()-1-2*gapEighth()));
+                     (int) (resizeButtonX()+resizeButtonWidth()-1-2*gapEighth()), (int) (resizeButtonY()+resizeButtonHeight()-1-2*gapEighth()),
+                     (int) (resizeButtonX()+resizeButtonWidth()-1-4*gapEighth()), (int) (resizeButtonY()+resizeButtonHeight()-1-2*gapEighth()));
       _zoom.drawLine(g, 1,
-                     (int) (dragAreaX()+dragAreaWidth()-1-2*gapEighth()), (int) (dragAreaY()+dragAreaHeight()-1-2*gapEighth()),
-                     (int) (dragAreaX()+dragAreaWidth()-1-2*gapEighth()), (int) (dragAreaY()+dragAreaHeight()-1-4*gapEighth()));
+                     (int) (resizeButtonX()+resizeButtonWidth()-1-2*gapEighth()), (int) (resizeButtonY()+resizeButtonHeight()-1-2*gapEighth()),
+                     (int) (resizeButtonX()+resizeButtonWidth()-1-2*gapEighth()), (int) (resizeButtonY()+resizeButtonHeight()-1-4*gapEighth()));
       _zoom.drawLine(g, 1,
-                     (int) (dragAreaX()+                  2*gapEighth()), (int) (dragAreaY()+                  2*gapEighth()),
-                     (int) (dragAreaX()+dragAreaWidth()-1-2*gapEighth()), (int) (dragAreaY()+dragAreaHeight()-1-2*gapEighth()));
+                     (int) (resizeButtonX()+                      2*gapEighth()), (int) (resizeButtonY()+                       2*gapEighth()),
+                     (int) (resizeButtonX()+resizeButtonWidth()-1-2*gapEighth()), (int) (resizeButtonY()+resizeButtonHeight()-1-2*gapEighth()));
     }
   };
 

--- a/src/java/dev/feeze/SchedulingPanorama.java
+++ b/src/java/dev/feeze/SchedulingPanorama.java
@@ -1855,8 +1855,14 @@ class SchedulingPanorama extends Panorama
                       }
                     _dragX += dx;
                     _dragY += dy;
-                    _leftRuler.changeWidth( dx);
-                    _topRuler .changeHeight(dy);
+                    if (e.getComponent() != _topRuler)
+                      {
+                        _leftRuler.changeWidth( dx);
+                      }
+                    if (e.getComponent() != _leftRuler)
+                      {
+                        _topRuler .changeHeight(dy);
+                      }
                   }
               }
           }

--- a/src/java/dev/feeze/SchedulingPanorama.java
+++ b/src/java/dev/feeze/SchedulingPanorama.java
@@ -1751,6 +1751,15 @@ class SchedulingPanorama extends Panorama
         dragAreaY() <= ey && ey < dragAreaY() + dragAreaHeight();
     }
 
+
+    /**
+     * mouseClicked action, to be redefined if needed.
+     */
+    void mouseClicked(MouseEvent e)
+    {
+    }
+
+
     private boolean _inDragArea = false;
 
 
@@ -1784,6 +1793,7 @@ class SchedulingPanorama extends Panorama
           @Override
           public void mouseClicked(MouseEvent e)
           {
+            WithDraggingArea.this.mouseClicked(e);
           }
 
           @Override
@@ -1974,6 +1984,48 @@ class SchedulingPanorama extends Panorama
 
     {
       setPreferredSize(new Dimension(_zoom.STANDARD_FONT_SIZE*10, 1));
+    }
+
+    @Override
+    void mouseClicked(MouseEvent e)
+    {
+      var x = e.getX();
+      var y = e.getY();
+      var c = e.getComponent();
+      if (x >= 0 && x < c.getWidth() &&
+          y >= 0 && y < c.getHeight() &&
+          !inDragArea(x, y))
+        {
+          if (y >= cpusY() && y < cpusYHeaderBottom())
+            {
+              synchronized (SchedulingPanorama.this)
+                {
+                  _cpusEnabled = !_cpusEnabled;
+                  _threads = null;
+                }
+              c.repaint();
+              SchedulingPanorama.this.repaint();
+            }
+          else
+            {
+              var ti = threadAt(y);
+              var u = thread(ti).user();
+              if (ti >= 0 &&
+                  ti <= numThreads()      &&
+                  isFirstThreadOfUser(ti) &&
+                  y >= threadYUserTop(ti) &&
+                  y < threadYUserBot(ti)     )
+                {
+                  synchronized (SchedulingPanorama.this)
+                    {
+                      _usersEnabled[u._num] = !_usersEnabled[u._num];
+                      _threads = null;
+                    }
+                  c.repaint();
+                  SchedulingPanorama.this.repaint();
+                }
+            }
+        }
     }
 
     void changeWidth(int dx)

--- a/src/java/dev/feeze/SchedulingPanorama.java
+++ b/src/java/dev/feeze/SchedulingPanorama.java
@@ -1835,11 +1835,11 @@ class SchedulingPanorama extends Panorama
                 var x = e.getX();
                 var y = e.getY();
                 var inResizeButton = inResizeButton(x,y);
-                if (inResizeButton != _inResizeButton)
+                if (inResizeButton != _inResizeButton && !_draggingDataArea)
                   {
                     _inResizeButton = inResizeButton;
                     setCursor(inResizeButton ? resizeCursor()
-                                         : Cursor.getDefaultCursor());
+                                             : Cursor.getDefaultCursor());
                   }
               }
           }

--- a/src/java/dev/feeze/SchedulingPanorama.java
+++ b/src/java/dev/feeze/SchedulingPanorama.java
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 package dev.feeze;
 
 import java.awt.Color;
+import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -1719,61 +1720,61 @@ class SchedulingPanorama extends Panorama
   }
 
   /**
-   * Component to draw scala as top ruler.
+   * Component with a dragging area
    */
-  public class Scala extends JComponent
+  public abstract class WithDraggingArea extends JComponent
   {
-
     /**
-     * Are we currently dragging, i.e., changing the height of this component?
+     * Cursor to use when mouse is over drag area
      */
-    boolean _dragging = false;
-
-    /**
-     * During _dragging, the last y position of the mouse that was processed to
-     * change the height.
-     */
-    int _dragY = 0;
-
-    int _preferredHeight;
-
-    /**
-     * Minimun height of Scale area, used to make sure it does not
-     * accidentally disappear when dragging.
-     */
-    int MIN_SCALA_HEIGHT() { return (int) (4*gapEighth()); }
+    abstract Cursor dragCursor();
 
     /**
      * Drag area is the area where you can grab the line and move it around.
      */
-    int dragAreaWidth        () { return (int) (16*gapEighth()); }
-    int dragAreaHeight       () { return (int) (4*gapEighth()); }
-    int dragAreaX            () { return (int) (getVisibleRect().x + getVisibleRect().width  - 24*gapEighth()); }
-    int dragAreaY            () { return (int) (getVisibleRect().y + getVisibleRect().height - dragAreaHeight()); }
+    abstract int dragAreaWidth        ();
+    abstract int dragAreaHeight       ();
+    abstract int dragAreaX            ();
+    abstract int dragAreaY            ();
 
 
     /**
-     * Are the given relative (to Scala) coordinates within the drag
+     * Are the given relative (to ThreadNames) coordinates within the drag
      * button?
      */
     boolean inDragArea(int x, int y)
     {
+      var ex = x;
+      var ey = y;
       return
-        dragAreaX() <= x && x < dragAreaX() + dragAreaWidth() &&
-        dragAreaY() <= y && y < dragAreaY() + dragAreaHeight();
+        dragAreaX() <= ex && ex < dragAreaX() + dragAreaWidth() &&
+        dragAreaY() <= ey && ey < dragAreaY() + dragAreaHeight();
     }
 
+    private boolean _inDragArea = false;
 
-    public Scala()
+
+    /**
+     * Are we currently dragging, i.e., changing the width of this component?
+     */
+    boolean _dragging = false;
+
+    /**
+     * During _dragging, the last x/y position of the mouse that was processed to
+     * change the width.
+     */
+    int _dragX = 0;
+    int _dragY = 0;
+
     {
-      setPreferredSize(new Dimension(1, _zoom.STANDARD_FONT_SIZE*7/8*5+16));
+      setPreferredSize(new Dimension(1, 1));
       addMouseListener(new MouseListener()
         {
 
           @Override
           public void mouseReleased(MouseEvent e)
           {
-            if (e.getComponent() == Scala.this &&
+            if (e.getComponent() == WithDraggingArea.this &&
                 SwingUtilities.isLeftMouseButton(e))
               {
                 _dragging = false;
@@ -1798,13 +1799,14 @@ class SchedulingPanorama extends Panorama
           @Override
           public void mousePressed(MouseEvent e)
           {
-            if (e.getComponent() == Scala.this &&
+            if (e.getComponent() == WithDraggingArea.this &&
                 SwingUtilities.isLeftMouseButton(e))
               {
                 var x = e.getX();
                 var y = e.getY();
                 if (inDragArea(x, y))
                   {
+                    _dragX = x;
                     _dragY = y;
                     _dragging = true;
                   }
@@ -1818,31 +1820,84 @@ class SchedulingPanorama extends Panorama
           @Override
           public void mouseMoved(MouseEvent e)
           {
+            if (e.getComponent() == WithDraggingArea.this)
+              {
+                var x = e.getX();
+                var y = e.getY();
+                var inDragArea = inDragArea(x,y);
+                if (inDragArea != _inDragArea)
+                  {
+                    _inDragArea = inDragArea;
+                    setCursor(inDragArea ? dragCursor()
+                                         : Cursor.getDefaultCursor());
+                  }
+              }
           }
 
           @Override
           public void mouseDragged(MouseEvent e)
           {
-            if (e.getComponent() == Scala.this &&
+            if (e.getComponent() == WithDraggingArea.this &&
                 SwingUtilities.isLeftMouseButton(e) &&
                 _dragging)
               {
+                var dx = e.getX() - _dragX;
                 var dy = e.getY() - _dragY;
-                if (dy != 0)
+                if (dx != 0 || dy != 0)
                   {
+                    if (dx > 0)
+                      {
+                        dx = Math.min(dx, SchedulingPanorama.this.getVisibleRect().width - MIN_PANORAMA_WIDTH());
+                      }
                     if (dy > 0)
                       {
                         dy = Math.min(dy, SchedulingPanorama.this.getVisibleRect().height - MIN_PANORAMA_HEIGHT());
                       }
-                    changeHeight(dy);
+                    _dragX += dx;
                     _dragY += dy;
+                    _leftRuler.changeWidth( dx);
+                    _topRuler .changeHeight(dy);
                   }
               }
           }
 
         });
+
     }
 
+  }
+
+
+  /**
+   * Component to draw scala as top ruler.
+   */
+  public class Scala extends WithDraggingArea
+  {
+
+    int _preferredHeight;
+
+    /**
+     * Minimun height of Scale area, used to make sure it does not
+     * accidentally disappear when dragging.
+     */
+    int MIN_SCALA_HEIGHT() { return (int) (4*gapEighth()); }
+
+    /**
+     * Cursor to use when mouse is over drag area
+     */
+    Cursor dragCursor() { return Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR); };
+
+    /**
+     * Drag area is the area where you can grab the line and move it around.
+     */
+    int dragAreaWidth        () { return (int) (16*gapEighth()); }
+    int dragAreaHeight       () { return (int) (4*gapEighth()); }
+    int dragAreaX            () { return (int) (getVisibleRect().x + getVisibleRect().width  - 24*gapEighth()); }
+    int dragAreaY            () { return (int) (getVisibleRect().y + getVisibleRect().height - dragAreaHeight()); }
+
+    {
+      setPreferredSize(new Dimension(1, _zoom.STANDARD_FONT_SIZE*7/8*5+16));
+    }
 
     void changeHeight(int dy)
     {
@@ -1889,27 +1944,19 @@ class SchedulingPanorama extends Panorama
   /**
    * Component to draw thread names as left ruler.
    */
-  public class ThreadNames extends JComponent
+  public class ThreadNames extends WithDraggingArea
   {
-
-    /**
-     * Are we currently dragging, i.e., changing the width of this component?
-     */
-    boolean _dragging = false;
-
-    /**
-     * During _dragging, the last x position of the mouse that was processed to
-     * change the width.
-     */
-    int _dragX = 0;
-
-    int _preferredWidth;
 
     /**
      * Minimun width of ThreadNames area, used to make sure it does not
      * accidentally disappear when dragging.
      */
     int MIN_THREADNAMES_WIDTH() { return (int) (4*gapEighth()); }
+
+    /**
+     * Cursor to use when mouse is over drag area
+     */
+    Cursor dragCursor() { return Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR); };
 
     /**
      * Drag area is the area where you can grab the line and move it around.
@@ -1919,137 +1966,8 @@ class SchedulingPanorama extends Panorama
     int dragAreaX            () { return (int) (getVisibleRect().x + getVisibleRect().width  - dragAreaWidth()); }
     int dragAreaY            () { return (int) (getVisibleRect().y + getVisibleRect().height - 24*gapEighth() ); }
 
-
-    /**
-     * Are the given relative (to ThreadNames) coordinates within the drag
-     * button?
-     */
-    boolean inDragArea(int x, int y)
     {
-      return
-        dragAreaX() <= x && x < dragAreaX() + dragAreaWidth() &&
-        dragAreaY() <= y && y < dragAreaY() + dragAreaHeight();
-    }
-
-
-    /**
-     * Constructor
-     */
-    public ThreadNames()
-    {
-      _preferredWidth  = _zoom.STANDARD_FONT_SIZE*10;
-      setPreferredSize(new Dimension(_preferredWidth, 1));
-      addMouseListener(new MouseListener()
-        {
-
-          @Override
-          public void mouseReleased(MouseEvent e)
-          {
-            if (e.getComponent() == ThreadNames.this &&
-                SwingUtilities.isLeftMouseButton(e))
-              {
-                _dragging = false;
-              }
-          }
-
-          @Override
-          public void mouseClicked(MouseEvent e)
-          {
-            var x = e.getX();
-            var y = e.getY();
-            var c = e.getComponent();
-            if (x >= 0 && x < c.getWidth() &&
-                y >= 0 && y < c.getHeight() &&
-                !inDragArea(x, y))
-              {
-                if (y >= cpusY() && y < cpusYHeaderBottom())
-                  {
-                    synchronized (SchedulingPanorama.this)
-                      {
-                        _cpusEnabled = !_cpusEnabled;
-                        _threads = null;
-                      }
-                    c.repaint();
-                    SchedulingPanorama.this.repaint();
-                  }
-                else
-                  {
-                    var ti = threadAt(y);
-                    var u = thread(ti).user();
-                    if (ti >= 0 &&
-                        ti <= numThreads()      &&
-                        isFirstThreadOfUser(ti) &&
-                        y >= threadYUserTop(ti) &&
-                        y < threadYUserBot(ti)     )
-                      {
-                        synchronized (SchedulingPanorama.this)
-                          {
-                            _usersEnabled[u._num] = !_usersEnabled[u._num];
-                            _threads = null;
-                          }
-                        c.repaint();
-                        SchedulingPanorama.this.repaint();
-                      }
-                  }
-              }
-          }
-
-          @Override
-          public void mouseEntered(MouseEvent e)
-          {
-          }
-
-          @Override
-          public void mouseExited(MouseEvent e)
-          {
-          }
-
-          @Override
-          public void mousePressed(MouseEvent e)
-          {
-            if (e.getComponent() == ThreadNames.this &&
-                SwingUtilities.isLeftMouseButton(e))
-              {
-                var x = e.getX();
-                var y = e.getY();
-                if (inDragArea(x, y))
-                  {
-                    _dragX = x;
-                    _dragging = true;
-                  }
-              }
-          }
-
-        });
-      addMouseMotionListener(new MouseMotionListener()
-        {
-
-          @Override
-          public void mouseMoved(MouseEvent e)
-          {
-          }
-
-          @Override
-          public void mouseDragged(MouseEvent e)
-          {
-            if (e.getComponent() == ThreadNames.this &&
-                SwingUtilities.isLeftMouseButton(e) &&
-                _dragging)
-              {
-                var dx = e.getX() - _dragX;
-                if (dx != 0)
-                  {
-                    if (dx > 0)
-                      {
-                        dx = Math.min(dx, SchedulingPanorama.this.getVisibleRect().width - MIN_PANORAMA_WIDTH());
-                      }
-                    changeWidth(dx);
-                    _dragX += dx;
-                  }
-              }
-          }
-
-        });
+      setPreferredSize(new Dimension(_zoom.STANDARD_FONT_SIZE*10, 1));
     }
 
     void changeWidth(int dx)
@@ -2218,22 +2136,21 @@ class SchedulingPanorama extends Panorama
   /**
    * top left corner
    */
-  JComponent _topLeft = new JComponent()
+  JComponent _topLeft = new TopLeft();
+
+
+  @Override
+  public JComponent topLeft()
   {
-    JComponent me = this;
+    return _topLeft;
+  }
 
-    /**
-     * Are we currently dragging, i.e., changing the width of this component?
-     */
-    boolean _dragging = false;
 
-    /**
-     * During _dragging, the last x/y position of the mouse that was processed to
-     * change the width.
-     */
-    int _dragX = 0;
-    int _dragY = 0;
-
+  /**
+   * Component to draw top left area
+   */
+  class TopLeft extends WithDraggingArea
+  {
 
     /**
      * Minimun width of topLeft area, used to make sure it does not accidentally
@@ -2247,6 +2164,10 @@ class SchedulingPanorama extends Panorama
      */
     int MIN_HEIGHT() { return (int) (8*gapEighth()); }
 
+    /**
+     * Cursor to use when mouse is over drag area
+     */
+    Cursor dragCursor() { return Cursor.getPredefinedCursor(Cursor.NW_RESIZE_CURSOR); };
 
     /**
      * Drag area is the area where you can grab the line and move it around.
@@ -2256,106 +2177,6 @@ class SchedulingPanorama extends Panorama
     int dragAreaX            () { return (int) (getWidth()  - dragAreaWidth() ); }
     int dragAreaY            () { return (int) (getHeight() - dragAreaHeight()); }
 
-
-    /**
-     * Are the given relative (to ThreadNames) coordinates within the drag
-     * button?
-     */
-    boolean inDragArea(int x, int y)
-    {
-      var ex = x;
-      var ey = y;
-      return
-        dragAreaX() <= ex && ex < dragAreaX() + dragAreaWidth() &&
-        dragAreaY() <= ey && ey < dragAreaY() + dragAreaHeight();
-    }
-
-
-    {
-      setPreferredSize(new Dimension(1, 1));
-      addMouseListener(new MouseListener()
-        {
-
-          @Override
-          public void mouseReleased(MouseEvent e)
-          {
-            if (e.getComponent() == me &&
-                SwingUtilities.isLeftMouseButton(e))
-              {
-                _dragging = false;
-              }
-          }
-
-          @Override
-          public void mouseClicked(MouseEvent e)
-          {
-          }
-
-          @Override
-          public void mouseEntered(MouseEvent e)
-          {
-          }
-
-          @Override
-          public void mouseExited(MouseEvent e)
-          {
-          }
-
-          @Override
-          public void mousePressed(MouseEvent e)
-          {
-            if (e.getComponent() == me &&
-                SwingUtilities.isLeftMouseButton(e))
-              {
-                var x = e.getX();
-                var y = e.getY();
-                if (inDragArea(x, y))
-                  {
-                    _dragX = x;
-                    _dragY = y;
-                    _dragging = true;
-                  }
-              }
-          }
-
-        });
-      addMouseMotionListener(new MouseMotionListener()
-        {
-
-          @Override
-          public void mouseMoved(MouseEvent e)
-          {
-          }
-
-          @Override
-          public void mouseDragged(MouseEvent e)
-          {
-            if (e.getComponent() == me &&
-                SwingUtilities.isLeftMouseButton(e) &&
-                _dragging)
-              {
-                var dx = e.getX() - _dragX;
-                var dy = e.getY() - _dragY;
-                if (dx != 0 || dy != 0)
-                  {
-                    if (dx > 0)
-                      {
-                        dx = Math.min(dx, SchedulingPanorama.this.getVisibleRect().width - MIN_PANORAMA_WIDTH());
-                      }
-                    if (dy > 0)
-                      {
-                        dy = Math.min(dy, SchedulingPanorama.this.getVisibleRect().height - MIN_PANORAMA_HEIGHT());
-                      }
-                    _dragX += dx;
-                    _dragY += dy;
-                    _leftRuler.changeWidth( dx);
-                    _topRuler .changeHeight(dy);
-                  }
-              }
-          }
-
-        });
-    }
 
     protected void paintComponent(Graphics g)
     {
@@ -2392,13 +2213,6 @@ class SchedulingPanorama extends Panorama
                      (int) (dragAreaX()+dragAreaWidth()-1-2*gapEighth()), (int) (dragAreaY()+dragAreaHeight()-1-2*gapEighth()));
     }
   };
-
-
-  @Override
-  public JComponent topLeft()
-  {
-    return _topLeft;
-  }
 
 
   /*---------------------------------------------------------------------*/

--- a/src/java/dev/flang/swing/Panorama.java
+++ b/src/java/dev/flang/swing/Panorama.java
@@ -190,6 +190,13 @@ public abstract class Panorama extends JPanel
   protected JViewport _viewport;
 
 
+  /**
+   * While moving the data area around, used to indicate that we should not
+   * change the cursor when hovering.
+   */
+  protected boolean _draggingDataArea = false;
+
+
   /*--------------------------  constructors  ---------------------------*/
 
 

--- a/src/java/dev/flang/swing/PanoramaListener.java
+++ b/src/java/dev/flang/swing/PanoramaListener.java
@@ -30,6 +30,7 @@ package dev.flang.swing;
 /*---------------------------------------------------------------------*/
 
 import java.awt.Component;
+import java.awt.Cursor;
 import java.awt.KeyEventDispatcher;
 import java.awt.KeyboardFocusManager;
 import java.awt.Point;
@@ -203,6 +204,14 @@ class PanoramaListener
       {
         ar.endRepeat();
       }
+
+    if ((SwingUtilities.isLeftMouseButton  (e) ||
+         SwingUtilities.isMiddleMouseButton(e)    ) &&
+        c ==  _p)
+      {
+        _p.setCursor(Cursor.getDefaultCursor());
+        _p._draggingDataArea = false;
+      }
   }
 
 
@@ -362,6 +371,7 @@ class PanoramaListener
    *
    * @param e the mouse event.
    */
+  @Override
   public void mouseDragged(MouseEvent e)
   {
     var ar = _autorepeat;
@@ -373,6 +383,8 @@ class PanoramaListener
               {
                 if (e.getComponent() ==  _p)
                   {
+                    _p.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
+                    _p._draggingDataArea = true;
                     if (_dragX > 0) /* repeat thread sets this to -1 to disable dragging */
                       { /* stop auto-repeat */
                         ar._activeComponent = null;


### PR DESCRIPTION
fix #96. 

Also include a major cleanup of the scale, thread names and top-left areas removing duplication of the dragging code.

