### PR TITLE
Add Linux packaging: tar.gz, deb and rpm for amd64 and arm64

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,8 @@
+name: Install feeze build dependencies
+description: JDK 25, libgc, libelf, linux-tools and pandoc
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: "$GITHUB_ACTION_PATH/install-deps.sh"

--- a/.github/actions/install-deps/install-deps.sh
+++ b/.github/actions/install-deps/install-deps.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# This file is part of the feeze scheduling analysis tool.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+# -----------------------------------------------------------------------
+#
+#  Copyright (c) 2025, Tokiwa Software GmbH, Germany
+#
+#  Source of install-deps.sh
+#
+#  This installs the toolchain needed to build and package feeze on a
+#  GitHub Actions runner
+#
+#
+# -----------------------------------------------------------------------
+sudo apt-get update
+sudo apt-get install openjdk-25-jdk-headless libgc1 libgc-dev
+sudo apt-get install libelf-dev
+sudo apt-get install linux-tools-`uname -r`
+sudo apt-get install pandoc
+
+echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
+echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH

--- a/.github/actions/install-deps/install-deps.sh
+++ b/.github/actions/install-deps/install-deps.sh
@@ -23,7 +23,6 @@
 #  This installs the toolchain needed to build and package feeze on a
 #  GitHub Actions runner
 #
-#
 # -----------------------------------------------------------------------
 sudo apt-get update
 sudo apt-get install openjdk-25-jdk-headless libgc1 libgc-dev

--- a/.github/actions/install-deps/install-deps.sh
+++ b/.github/actions/install-deps/install-deps.sh
@@ -28,6 +28,7 @@ sudo apt-get update
 sudo apt-get install -y \
   openjdk-25-jdk-headless libgc1 libgc-dev \
   libelf-dev \
+  binutils\
   pandoc \
   "linux-tools-$(uname -r)"
 

--- a/.github/actions/install-deps/install-deps.sh
+++ b/.github/actions/install-deps/install-deps.sh
@@ -32,5 +32,7 @@ sudo apt-get install -y \
   pandoc \
   "linux-tools-$(uname -r)"
 
-echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
-echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
+JAVA_HOME="/usr/lib/jvm/java-25-openjdk-$(dpkg --print-architecture)"
+test -x "$JAVA_HOME/bin/javac"
+echo "JAVA_HOME=$JAVA_HOME" >>"$GITHUB_ENV"
+echo "$JAVA_HOME/bin"       >>"$GITHUB_PATH"

--- a/.github/actions/install-deps/install-deps.sh
+++ b/.github/actions/install-deps/install-deps.sh
@@ -25,10 +25,11 @@
 #
 # -----------------------------------------------------------------------
 sudo apt-get update
-sudo apt-get install openjdk-25-jdk-headless libgc1 libgc-dev
-sudo apt-get install libelf-dev
-sudo apt-get install linux-tools-`uname -r`
-sudo apt-get install pandoc
+sudo apt-get install -y \
+  openjdk-25-jdk-headless libgc1 libgc-dev \
+  libelf-dev \
+  pandoc \
+  "linux-tools-$(uname -r)"
 
 echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
 echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH

--- a/.github/actions/test-package/test-package.sh
+++ b/.github/actions/test-package/test-package.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# This file is part of the feeze scheduling analysis tool.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+# -----------------------------------------------------------------------
+#
+#  Copyright (c) 2025, Tokiwa Software GmbH, Germany
+#
+#  Source of test-package.sh
+#
+#  This installs a built feeze package inside a clean container and checks
+#  that it is usable. Runs inside the container, not on the runner.
+#
+# -----------------------------------------------------------------------
+
+set -eux
+
+if [ -f /etc/debian_version ]; then
+  apt-get update
+  apt-get install -y ./*.deb
+else
+  dnf install -y ./*.rpm
+fi
+
+command -v feeze
+command -v feeze_recorder
+
+# Swing needs a display, so assert only that the preflight checks in bin/feeze
+# pass - that covers the JDK 25 and libgc dependencies.
+feeze >/tmp/out 2>&1 || true
+if grep -qE "not found in .PATH|must be at least 25|libgc.so not installed" /tmp/out; then
+  cat /tmp/out
+  exit 1
+fi

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -88,12 +88,14 @@ jobs:
 
       - name: Install build and packaging dependencies
         run: |
-          set -eux
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            make clang llvm libelf-dev zlib1g-dev libgc-dev pkg-config file \
-            systemtap-sdt-dev \
-            dpkg-dev rpm zstd libcap2-bin
+          sudo apt-get install openjdk-25-jdk-headless libgc1 libgc-dev
+          sudo apt-get install libelf-dev
+          sudo apt-get install linux-tools-`uname -r`
+          sudo apt-get install pandoc
+
+          echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
+          echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
 
       - name: Ensure bpftool works on current kernel
       # taken from https://github.com/actions/runner-images/issues/14203

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,247 @@
+name: Build feeze packages
+
+on:
+  push:
+    branches: [packages-ci]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: '25'
+  FUZION_VERSION: '0.098'
+
+jobs:
+
+  facts:
+    name: Facts
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.f.outputs.version }}
+      release-kind: ${{ steps.f.outputs.release-kind }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: f
+        run: |
+          set -eu
+          # If this is a tag launch, the version is taken from the tag name,
+          # otherwise the version is taken from the version.txt file, and the type becomes nightly.
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "version=${GITHUB_REF_NAME#v}" >>"$GITHUB_OUTPUT"
+            echo "release-kind=release"         >>"$GITHUB_OUTPUT"
+          else
+            echo "version=$(cat version.txt)"   >>"$GITHUB_OUTPUT"
+            echo "release-kind=nightly"         >>"$GITHUB_OUTPUT"
+          fi
+
+  # ---------------------------------------------------------------------------
+  # One native runner per architecture.
+  # All packaging logic lives in packaging.mk;
+  # this job only provides the toolchain and calls make.
+  # ---------------------------------------------------------------------------
+  package-linux:
+    name: Package for Linux (${{ matrix.arch }})
+    needs: [facts]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: amd64, runner: ubuntu-24.04,     elf_arch: x86-64,  vmlinux_arch: x86_64 }
+          - { arch: arm64, runner: ubuntu-24.04-arm, elf_arch: aarch64, vmlinux_arch: arm64 }
+    env:
+      VERSION: ${{ needs.facts.outputs.version }}
+      RELEASE_KIND: ${{ needs.facts.outputs.release-kind }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install build and packaging dependencies
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            make clang llvm libelf-dev zlib1g-dev libgc-dev pkg-config file \
+            systemtap-sdt-dev \
+            dpkg-dev rpm zstd libcap2-bin
+
+      - name: Provide static bpftool
+        env:
+          BPFTOOL_VERSION: v7.5.0
+        run: |
+          set -eux
+          url="https://github.com/libbpf/bpftool/releases/download/${BPFTOOL_VERSION}/bpftool-${BPFTOOL_VERSION}-${{ matrix.arch }}.tar.gz"
+          curl -fsSL -o /tmp/bpftool.tar.gz "$url"
+          tar xzf /tmp/bpftool.tar.gz -C /tmp
+          sudo install -m 755 /tmp/bpftool /usr/local/bin/bpftool
+          echo "BPFTOOL=/usr/local/bin/bpftool" >>"$GITHUB_ENV"
+          /usr/local/bin/bpftool version
+
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: zulu          # ships jmods for amd64 and arm64
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Cache Fuzion toolchain
+        id: fuzion-cache
+        uses: actions/cache@v4
+        with:
+          path: .fuzion-home
+          key: fuzion-${{ env.FUZION_VERSION }}-${{ matrix.arch }}-jdk${{ env.JAVA_VERSION }}
+
+      # The published fuzion release contains a native lib/libfuzion_rt.so, so
+      # it is only usable when it matches this runner. Probe it and fall back to
+      # a source build.
+      - name: Provide Fuzion toolchain
+        if: steps.fuzion-cache.outputs.cache-hit != 'true'
+        run: |
+          set -eux
+          work="$(mktemp -d)"; ok=0
+          if curl -fsSL -o "$work/f.tar.gz" \
+              "https://github.com/tokiwa-software/fuzion/releases/download/v${FUZION_VERSION}/fuzion_${FUZION_VERSION}.tar.gz"; then
+            tar xzf "$work/f.tar.gz" -C "$work"
+            home="$work/fuzion_${FUZION_VERSION}"
+            file "$home/lib/libfuzion_rt.so" | grep -q '${{ matrix.elf_arch }}' && ok=1 \
+              || echo "::notice::prebuilt fuzion is not ${{ matrix.elf_arch }}, building from source"
+          fi
+          if [ "$ok" -eq 0 ]; then
+            git clone --depth 1 --branch "v${FUZION_VERSION}" https://github.com/tokiwa-software/fuzion "$work/src" \
+              || git clone --depth 1 https://github.com/tokiwa-software/fuzion "$work/src"
+            make -C "$work/src" -j"$(nproc)"
+            home="$work/src/build"
+          fi
+          rm -rf .fuzion-home && cp -a "$home" .fuzion-home
+
+      - name: Export FUZION_HOME
+        run: echo "FUZION_HOME=$GITHUB_WORKSPACE/.fuzion-home" >>"$GITHUB_ENV"
+
+      - name: Verify Fuzion toolchain
+        run: |
+          set -eu
+          file "$FUZION_HOME/lib/libfuzion_rt.so" | grep -q '${{ matrix.elf_arch }}' || {
+            echo "::error::cached Fuzion toolchain is not ${{ matrix.elf_arch }}"; exit 1; }
+          "$FUZION_HOME/bin/fz" -version
+
+      # Temporary: drop once the arch-parametrised Makefile is merged.
+      - name: Patch Makefile for multi-arch
+        run: |
+          set -eu
+          if grep -q 'vmlinux.h/include/x86_64/' Makefile; then
+            echo "::warning::patching hardcoded vmlinux.h arch path"
+            sed -i "s#vmlinux.h/include/x86_64/#vmlinux.h/include/${{ matrix.vmlinux_arch }}/#" Makefile
+          fi
+          if grep -q "sed 's/x86_64/x86/'" Makefile; then
+            sed -i "s#sed 's/x86_64/x86/'#sed -e 's/x86_64/x86/' -e 's/aarch64/arm64/'#" Makefile
+          fi
+
+      # Build only what is shipped: `make all` also runs the pandoc manual rules
+      - name: Build
+        run: |
+            make -j"$(nproc)" \
+            build/bin/feeze \
+            build/bin/feeze_desktop \
+            build/bin/feeze_recorder
+
+
+      - name: Create packages
+        run: make packages
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packages-linux-${{ matrix.arch }}
+          path: |
+            *.tar.gz
+            *.deb
+            *.rpm
+          if-no-files-found: error
+
+  test-packages:
+    name: Test ${{ matrix.format }} on ${{ matrix.arch }}
+    needs: [package-linux]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: amd64, runner: ubuntu-24.04,     format: deb, image: 'debian:trixie' }
+          - { arch: amd64, runner: ubuntu-24.04,     format: rpm, image: 'fedora:43' }
+          - { arch: arm64, runner: ubuntu-24.04-arm, format: deb, image: 'debian:trixie' }
+          - { arch: arm64, runner: ubuntu-24.04-arm, format: rpm, image: 'fedora:43' }
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages-linux-${{ matrix.arch }}
+      - name: Install in a clean container
+        run: |
+          set -eux
+          docker run --rm -v "$PWD:/pkg" -w /pkg '${{ matrix.image }}' sh -eux -c '
+            if [ "${{ matrix.format }}" = deb ]; then
+              apt-get update && apt-get install -y ./*.deb
+            else
+              dnf install -y ./*.rpm
+            fi
+            command -v feeze
+            command -v feeze_recorder
+            # Swing needs a display, so assert only that the preflight checks in
+            # bin/feeze pass - that covers the JDK 25 and libgc dependencies.
+            feeze >/tmp/out 2>&1 || true
+            echo "----- feeze output -----"; cat /tmp/out; echo "------------------------"
+            rpm -q java-25-openjdk gc elfutils-libelf zlib || true
+            java -version 2>&1 || echo "java not on PATH"
+            ! grep -qE "not found in .PATH|must be at least 25|libgc.so not installed" /tmp/out
+          '
+
+  release:
+    name: Publish release
+    # Everything except pull requests: forks do not get contents:write and the
+    # upload would fail with 403.
+    if: github.event_name != 'pull_request'
+    needs: [facts, test-packages]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: packages-linux-*
+          merge-multiple: true
+          path: artifacts
+
+      - name: Refuse to publish a partial set
+        run: |
+          set -eu
+          for p in '*-amd64.deb' '*-arm64.deb' '*-amd64.rpm' '*-arm64.rpm' \
+                   '*-amd64.tar.gz' '*-arm64.tar.gz'; do
+            ls artifacts/$p >/dev/null 2>&1 \
+              || { echo "::error::missing artifact matching $p"; exit 1; }
+          done
+
+      - id: tag
+        run: |
+          set -eu
+          if [ "$GITHUB_REF_TYPE" = tag ]; then
+            echo "name=$GITHUB_REF_NAME" >>"$GITHUB_OUTPUT"
+            echo "pre=false"             >>"$GITHUB_OUTPUT"
+            echo "latest=true"           >>"$GITHUB_OUTPUT"
+          else
+            # A single moving tag: the release is replaced on every push instead
+            # of accumulating one entry per commit.
+            echo "name=nightly"          >>"$GITHUB_OUTPUT"
+            echo "pre=true"              >>"$GITHUB_OUTPUT"
+            echo "latest=false"          >>"$GITHUB_OUTPUT"
+          fi
+
+      - uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name == 'nightly' && format('nightly {0} ({1})', needs.facts.outputs.version, github.sha) || steps.tag.outputs.name }}
+          prerelease: ${{ steps.tag.outputs.pre }}
+          make_latest: ${{ steps.tag.outputs.latest }}
+          files: artifacts/*
+          draft: false
+          generate_release_notes: true

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -46,7 +46,8 @@ jobs:
       release-kind: ${{ steps.f.outputs.release-kind }}
     steps:
       - uses: actions/checkout@v5
-      - id: f
+      - name: Determine version and release kind
+        id: f
         run: |
           set -eu
           # If this is a tag launch, the version is taken from the tag name,
@@ -163,7 +164,8 @@ jobs:
               || { echo "::error::missing artifact matching $p"; exit 1; }
           done
 
-      - id: tag
+      - name: Choose tag name
+        id: tag
         run: |
           set -eu
           if [ "$GITHUB_REF_TYPE" = tag ]; then

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -86,47 +86,6 @@ jobs:
         with:
           distribution: zulu          # ships jmods for amd64 and arm64
           java-version: ${{ env.JAVA_VERSION }}
-
-      - name: Cache Fuzion toolchain
-        id: fuzion-cache
-        uses: actions/cache@v4
-        with:
-          path: .fuzion-home
-          key: fuzion-${{ env.FUZION_VERSION }}-${{ matrix.arch }}-jdk${{ env.JAVA_VERSION }}
-
-      # The published fuzion release contains a native lib/libfuzion_rt.so, so
-      # it is only usable when it matches this runner. Probe it and fall back to
-      # a source build.
-      - name: Provide Fuzion toolchain
-        if: steps.fuzion-cache.outputs.cache-hit != 'true'
-        run: |
-          set -eux
-          work="$(mktemp -d)"; ok=0
-          if curl -fsSL -o "$work/f.tar.gz" \
-              "https://github.com/tokiwa-software/fuzion/releases/download/v${FUZION_VERSION}/fuzion_${FUZION_VERSION}.tar.gz"; then
-            tar xzf "$work/f.tar.gz" -C "$work"
-            home="$work/fuzion_${FUZION_VERSION}"
-            file "$home/lib/libfuzion_rt.so" | grep -q '${{ matrix.elf_arch }}' && ok=1 \
-              || echo "::notice::prebuilt fuzion is not ${{ matrix.elf_arch }}, building from source"
-          fi
-          if [ "$ok" -eq 0 ]; then
-            git clone --depth 1 --branch "v${FUZION_VERSION}" https://github.com/tokiwa-software/fuzion "$work/src" \
-              || git clone --depth 1 https://github.com/tokiwa-software/fuzion "$work/src"
-            make -C "$work/src" -j"$(nproc)"
-            home="$work/src/build"
-          fi
-          rm -rf .fuzion-home && cp -a "$home" .fuzion-home
-
-      - name: Export FUZION_HOME
-        run: echo "FUZION_HOME=$GITHUB_WORKSPACE/.fuzion-home" >>"$GITHUB_ENV"
-
-      - name: Verify Fuzion toolchain
-        run: |
-          set -eu
-          file "$FUZION_HOME/lib/libfuzion_rt.so" | grep -q '${{ matrix.elf_arch }}' || {
-            echo "::error::cached Fuzion toolchain is not ${{ matrix.elf_arch }}"; exit 1; }
-          "$FUZION_HOME/bin/fz" -version
-
       # Temporary: drop once the arch-parametrised Makefile is merged.
       - name: Patch Makefile for multi-arch
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -223,7 +223,7 @@ jobs:
           else
             # A single moving tag: the release is replaced on every push instead
             # of accumulating one entry per commit.
-            echo "name=nightly"          >>"$GITHUB_OUTPUT"
+            echo "name=snapshot"          >>"$GITHUB_OUTPUT"
             echo "pre=true"              >>"$GITHUB_OUTPUT"
             echo "latest=false"          >>"$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -181,12 +181,13 @@ jobs:
             echo "latest=false"          >>"$GITHUB_OUTPUT"
           fi
 
-      - uses: softprops/action-gh-release@v3
+      - name: Publish release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
-          tag_name: ${{ steps.tag.outputs.name }}
+          tag: ${{ steps.tag.outputs.name }}
           name: ${{ steps.tag.outputs.name == 'snapshot' && format('snapshot {0} ({1})', needs.facts.outputs.version, github.sha) || steps.tag.outputs.name }}
           prerelease: ${{ steps.tag.outputs.pre }}
-          make_latest: ${{ steps.tag.outputs.latest }}
-          files: artifacts/*
-          draft: false
-          generate_release_notes: true
+          makeLatest: ${{ steps.tag.outputs.latest }}
+          artifacts: artifacts/*
+          generateReleaseNotes: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -24,6 +24,7 @@
 #
 #
 # -----------------------------------------------------------------------
+
 name: Build feeze packages
 
 on:
@@ -86,16 +87,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install build and packaging dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install openjdk-25-jdk-headless libgc1 libgc-dev
-          sudo apt-get install libelf-dev
-          sudo apt-get install linux-tools-`uname -r`
-          sudo apt-get install pandoc
-
-          echo "JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64" >> $GITHUB_ENV
-          echo "/usr/lib/jvm/java-25-openjdk-amd64/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-deps
 
       - name: Ensure bpftool works on current kernel
       # taken from https://github.com/actions/runner-images/issues/14203

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -38,7 +38,6 @@ permissions:
 
 env:
   JAVA_VERSION: '25'
-  FUZION_VERSION: '0.098'
 
 jobs:
 
@@ -94,18 +93,6 @@ jobs:
             make clang llvm libelf-dev zlib1g-dev libgc-dev pkg-config file \
             systemtap-sdt-dev \
             dpkg-dev rpm zstd libcap2-bin
-
-      - name: Provide static bpftool
-        env:
-          BPFTOOL_VERSION: v7.5.0
-        run: |
-          set -eux
-          url="https://github.com/libbpf/bpftool/releases/download/${BPFTOOL_VERSION}/bpftool-${BPFTOOL_VERSION}-${{ matrix.arch }}.tar.gz"
-          curl -fsSL -o /tmp/bpftool.tar.gz "$url"
-          tar xzf /tmp/bpftool.tar.gz -C /tmp
-          sudo install -m 755 /tmp/bpftool /usr/local/bin/bpftool
-          echo "BPFTOOL=/usr/local/bin/bpftool" >>"$GITHUB_ENV"
-          /usr/local/bin/bpftool version
 
 
       - uses: actions/setup-java@v5

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -138,6 +138,7 @@ jobs:
             *.deb
             *.rpm
           if-no-files-found: error
+          retention-days: 5
 
   release:
     name: Publish release

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -22,7 +22,6 @@
 #  This is the GitHub Actions workflow building feeze packages for
 #  linux/amd64 and linux/arm64
 #
-#
 # -----------------------------------------------------------------------
 
 name: Build feeze packages

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -146,40 +146,28 @@ jobs:
           if-no-files-found: error
 
   test-packages:
-    name: Test ${{ matrix.format }} on ${{ matrix.arch }}
+    name: Test ${{ matrix.image }} on ${{ matrix.arch }}
     needs: [package-linux]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { arch: amd64, runner: ubuntu-24.04,     format: deb, image: 'debian:trixie' }
-          - { arch: amd64, runner: ubuntu-24.04,     format: rpm, image: 'fedora:43' }
-          - { arch: arm64, runner: ubuntu-24.04-arm, format: deb, image: 'debian:trixie' }
-          - { arch: arm64, runner: ubuntu-24.04-arm, format: rpm, image: 'fedora:43' }
+          - { arch: amd64, runner: ubuntu-24.04, image: 'debian:trixie' }
+          - { arch: amd64, runner: ubuntu-24.04, image: 'fedora:43' }
+          - { arch: arm64, runner: ubuntu-24.04-arm, image: 'debian:trixie' }
+          - { arch: arm64, runner: ubuntu-24.04-arm, image: 'fedora:43' }
     steps:
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with:
           name: packages-linux-${{ matrix.arch }}
       - name: Install in a clean container
         run: |
-          set -eux
-          docker run --rm -v "$PWD:/pkg" -w /pkg '${{ matrix.image }}' sh -eux -c '
-            if [ "${{ matrix.format }}" = deb ]; then
-              apt-get update && apt-get install -y ./*.deb
-            else
-              dnf install -y ./*.rpm
-            fi
-            command -v feeze
-            command -v feeze_recorder
-            # Swing needs a display, so assert only that the preflight checks in
-            # bin/feeze pass - that covers the JDK 25 and libgc dependencies.
-            feeze >/tmp/out 2>&1 || true
-            echo "----- feeze output -----"; cat /tmp/out; echo "------------------------"
-            rpm -q java-25-openjdk gc elfutils-libelf zlib || true
-            java -version 2>&1 || echo "java not on PATH"
-            ! grep -qE "not found in .PATH|must be at least 25|libgc.so not installed" /tmp/out
-          '
+          docker run --rm \
+            -v "$PWD:/pkg" \
+            -v "$PWD/.github/actions/test-package/test-package.sh:/test-package.sh:ro" \
+            -w /pkg '${{ matrix.image }}' sh /test-package.sh
 
   release:
     name: Publish release

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           set -eu
           # If this is a tag launch, the version is taken from the tag name,
-          # otherwise the version is taken from the version.txt file, and the type becomes nightly.
+          # otherwise from version.txt and the build is treated as a snapshot.
           if [ "$GITHUB_REF_TYPE" = "tag" ]; then
             echo "version=${GITHUB_REF_NAME#v}" >>"$GITHUB_OUTPUT"
             echo "release-kind=release"         >>"$GITHUB_OUTPUT"
@@ -92,25 +92,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             make clang llvm libelf-dev zlib1g-dev libgc-dev pkg-config file \
-            systemtap-sdt-dev binutils bpftool \
+            systemtap-sdt-dev \
             dpkg-dev rpm zstd libcap2-bin
 
-          # Build-time only: bpftool generates the BPF skeleton header and is
-          # not a runtime dependency of the packages.
-          #
-          # The Makefile defaults to /usr/sbin/bpftool, which on Ubuntu is a
-          # wrapper dispatching to linux-tools-$(uname -r). No such package
-          # exists for the runner's Azure kernel, so pick the real binary and
-          # verify it actually runs before relying on it.
-          for c in /usr/bin/bpftool /usr/sbin/bpftool; do
-            if [ -x "$c" ] && "$c" version >/dev/null 2>&1; then
-              echo "BPFTOOL=$c" >>"$GITHUB_ENV"
-              "$c" version
-              exit 0
-            fi
-          done
-          echo "::error::no working bpftool found"
-          exit 1
+      - name: Ensure bpftool works on current kernel
+      # taken from https://github.com/actions/runner-images/issues/14203
+        shell: bash
+        run: |
+          set -euo pipefail
+          KREL="$(uname -r)"
+          if ! /usr/sbin/bpftool -V >/dev/null 2>&1; then
+             printf "\033[1;35m*** using workaround for bpftool ***\033[0m\n"
+             if ! find /usr/lib -type f -name bpftool -perm -111 2>/dev/null | grep -q .; then
+               sudo apt-get update
+               sudo apt-get install -y --no-install-recommends linux-tools-generic
+             fi
+             FALLBACK="$(find /usr/lib -type f -name bpftool -perm -111 2>/dev/null | sort -V | tail -n 1)"
+             [[ -n "$FALLBACK" ]] || { echo "No bpftool payload found"; exit 1; }
+             sudo mkdir -p "/usr/lib/linux-tools/${KREL}"
+             sudo ln -sf "$FALLBACK" "/usr/lib/linux-tools/${KREL}/bpftool"
+          fi
+          /usr/sbin/bpftool -V
 
 
       - uses: actions/setup-java@v5

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -128,6 +128,17 @@ jobs:
       - name: Create packages
         run: make packages
 
+      - name: Test packages in clean containers
+        run: |
+          set -eux
+          for image in debian:trixie fedora:43; do
+            echo "== $image =="
+            docker run --rm \
+              -v "$PWD:/pkg" \
+              -v "$PWD/.github/actions/test-package/test-package.sh:/test-package.sh:ro" \
+              -w /pkg "$image" sh /test-package.sh
+          done
+
       - uses: actions/upload-artifact@v4
         with:
           name: packages-linux-${{ matrix.arch }}
@@ -137,36 +148,12 @@ jobs:
             *.rpm
           if-no-files-found: error
 
-  test-packages:
-    name: Test ${{ matrix.image }} on ${{ matrix.arch }}
-    needs: [package-linux]
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { arch: amd64, runner: ubuntu-24.04, image: 'debian:trixie' }
-          - { arch: amd64, runner: ubuntu-24.04, image: 'fedora:43' }
-          - { arch: arm64, runner: ubuntu-24.04-arm, image: 'debian:trixie' }
-          - { arch: arm64, runner: ubuntu-24.04-arm, image: 'fedora:43' }
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
-        with:
-          name: packages-linux-${{ matrix.arch }}
-      - name: Install in a clean container
-        run: |
-          docker run --rm \
-            -v "$PWD:/pkg" \
-            -v "$PWD/.github/actions/test-package/test-package.sh:/test-package.sh:ro" \
-            -w /pkg '${{ matrix.image }}' sh /test-package.sh
-
   release:
     name: Publish release
     # Everything except pull requests: forks do not get contents:write and the
     # upload would fail with 403.
     if: github.event_name != 'pull_request'
-    needs: [facts, test-packages]
+    needs: [facts, package-linux]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -73,8 +73,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { arch: amd64, runner: ubuntu-24.04,     elf_arch: x86-64,  vmlinux_arch: x86_64 }
-          - { arch: arm64, runner: ubuntu-24.04-arm, elf_arch: aarch64, vmlinux_arch: arm64 }
+          - { arch: amd64, runner: ubuntu-24.04,     elf_arch: x86-64 }
+          - { arch: arm64, runner: ubuntu-24.04-arm, elf_arch: aarch64 }
     env:
       VERSION: ${{ needs.facts.outputs.version }}
       RELEASE_KIND: ${{ needs.facts.outputs.release-kind }}
@@ -84,6 +84,7 @@ jobs:
           submodules: recursive
 
       - uses: ./.github/actions/install-deps
+
 
       - name: Ensure bpftool works on current kernel
       # taken from https://github.com/actions/runner-images/issues/14203
@@ -104,17 +105,6 @@ jobs:
           fi
           /usr/sbin/bpftool -V
 
-      # Temporary: drop once the arch-parametrised Makefile is merged.
-      - name: Patch Makefile for multi-arch
-        run: |
-          set -eu
-          if grep -q 'vmlinux.h/include/x86_64/' Makefile; then
-            echo "::warning::patching hardcoded vmlinux.h arch path"
-            sed -i "s#vmlinux.h/include/x86_64/#vmlinux.h/include/${{ matrix.vmlinux_arch }}/#" Makefile
-          fi
-          if grep -q "sed 's/x86_64/x86/'" Makefile; then
-            sed -i "s#sed 's/x86_64/x86/'#sed -e 's/x86_64/x86/' -e 's/aarch64/arm64/'#" Makefile
-          fi
 
       # Build only what is shipped: `make all` also runs the pandoc manual rules
       - name: Build

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -59,7 +59,8 @@ jobs:
             echo "release-kind=release"         >>"$GITHUB_OUTPUT"
           else
             echo "version=$(cat version.txt)"   >>"$GITHUB_OUTPUT"
-            echo "release-kind=nightly"         >>"$GITHUB_OUTPUT"
+            # A single moving tag: the release is replaced on every push
+            echo "release-kind=snapshot"         >>"$GITHUB_OUTPUT"
           fi
 
   # ---------------------------------------------------------------------------
@@ -91,8 +92,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             make clang llvm libelf-dev zlib1g-dev libgc-dev pkg-config file \
-            systemtap-sdt-dev \
+            systemtap-sdt-dev binutils bpftool \
             dpkg-dev rpm zstd libcap2-bin
+
+          # Build-time only: bpftool generates the BPF skeleton header and is
+          # not a runtime dependency of the packages.
+          #
+          # The Makefile defaults to /usr/sbin/bpftool, which on Ubuntu is a
+          # wrapper dispatching to linux-tools-$(uname -r). No such package
+          # exists for the runner's Azure kernel, so pick the real binary and
+          # verify it actually runs before relying on it.
+          for c in /usr/bin/bpftool /usr/sbin/bpftool; do
+            if [ -x "$c" ] && "$c" version >/dev/null 2>&1; then
+              echo "BPFTOOL=$c" >>"$GITHUB_ENV"
+              "$c" version
+              exit 0
+            fi
+          done
+          echo "::error::no working bpftool found"
+          exit 1
 
 
       - uses: actions/setup-java@v5
@@ -211,7 +229,7 @@ jobs:
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.name }}
-          name: ${{ steps.tag.outputs.name == 'nightly' && format('nightly {0} ({1})', needs.facts.outputs.version, github.sha) || steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name == 'snapshot' && format('snapshot {0} ({1})', needs.facts.outputs.version, github.sha) || steps.tag.outputs.name }}
           prerelease: ${{ steps.tag.outputs.pre }}
           make_latest: ${{ steps.tag.outputs.latest }}
           files: artifacts/*

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,3 +1,29 @@
+# This file is part of the feeze scheduling analysis tool.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+# -----------------------------------------------------------------------
+#
+#  Copyright (c) 2025, Tokiwa Software GmbH, Germany
+#
+#  Source of package.yml
+#
+#  This is the GitHub Actions workflow building feeze packages for
+#  linux/amd64 and linux/arm64
+#
+#
+# -----------------------------------------------------------------------
 name: Build feeze packages
 
 on:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -36,9 +36,6 @@ on:
 permissions:
   contents: read
 
-env:
-  JAVA_VERSION: '25'
-
 jobs:
 
   facts:
@@ -107,11 +104,6 @@ jobs:
           fi
           /usr/sbin/bpftool -V
 
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: zulu          # ships jmods for amd64 and arm64
-          java-version: ${{ env.JAVA_VERSION }}
       # Temporary: drop once the arch-parametrised Makefile is merged.
       - name: Patch Makefile for multi-arch
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+.vagrant/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,10 @@ clean:
 	rm -rf $(BUILD_DIR)
 	find . -name "*~" -exec rm {} \;
 
+# distribution packages (tar.gz, deb, rpm)
+#
+include $(FEEZE_REPO)/packaging.mk
+
 .PHONY: release
 release: clean all
 	rm -f feeze_$(VERSION_AND_PLATFORM).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,10 @@ LIBBPF_SRC  := $(LIBBPF)/src
 LIBBPF_OBJ  := $(BUILD_DIR)/libbpf_obj/libbpf.a
 LIBBPF_DEST := $(BUILD_DIR)/libbpf
 VMLINUX_H   := $(FEEZE_REPO)/vmlinux.h
-ARCH := $(shell uname -m | sed 's/x86_64/x86/')
+# Architecture names for the BPF target macro and for the pre-generated
+# vmlinux.h, which are spelled differently from uname -m.
+ARCH         := $(shell uname -m | sed -e 's/x86_64/x86/' -e 's/aarch64/arm64/')
+VMLINUX_ARCH := $(shell uname -m | sed -e 's/aarch64/arm64/')
 
 BPFTOOL ?= /usr/sbin/bpftool
 
@@ -109,7 +112,7 @@ $(BUILD_OBJ)/$(BPF_MAIN).bpf.o: src/bpf/$(BPF_MAIN).bpf.c $(LIBBPF_OBJ) $(VMLINU
 	mkdir -p $(@D)
 	clang -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		                     \
                      -I$(FEEZE_SRC)/include                                                  \
-		     -Ivmlinux.h/include/x86_64/ -I$(LIBBPF_DEST) $(CLANG_BPF_SYS_INCLUDES)  \
+		     -Ivmlinux.h/include/$(VMLINUX_ARCH)/ -I$(LIBBPF_DEST) $(CLANG_BPF_SYS_INCLUDES)  \
                      -c $(filter %.c,$^) -o $@
 
 # Generate BPF skeletons

--- a/bin/feeze
+++ b/bin/feeze
@@ -70,8 +70,8 @@ on Fedora, do
 
   > sudo yum install libgc
 "
-
-which "$FEEZE_JAVA" >/dev/null || (
+#there is no more which on rpm systems
+command -v "$FEEZE_JAVA" >/dev/null || (
     echo 1>&2 "*** java ($FEEZE_JAVA) not found in \$PATH."
     echo 1>&2 "$fix_java"
     exit 1)

--- a/bin/feeze
+++ b/bin/feeze
@@ -70,7 +70,7 @@ on Fedora, do
 
   > sudo yum install libgc
 "
-#there is no more which on rpm systems
+# Use 'command -v' instead of 'which' for compatibility with Fedora/RHEL
 command -v "$FEEZE_JAVA" >/dev/null || (
     echo 1>&2 "*** java ($FEEZE_JAVA) not found in \$PATH."
     echo 1>&2 "$fix_java"

--- a/packaging.mk
+++ b/packaging.mk
@@ -174,4 +174,4 @@ pkg-rpm: pkg-stage
 .PHONY: pkg-clean
 pkg-clean:
 	rm -rf $(PKG_DIR)
-	rm -f $(PKG_NAME)-*.tar.gz $(PKG_NAME)-*.deb $(PKG_NAME)-*.rpm \
+	rm -f $(PKG_NAME)-*.tar.gz $(PKG_NAME)-*.deb $(PKG_NAME)-*.rpm

--- a/packaging.mk
+++ b/packaging.mk
@@ -1,0 +1,152 @@
+#Metadata
+PKG_NAME       := feeze
+PKG_RELEASE    := 1
+PKG_MAINTAINER := Tokiwa Software GmbH <siebert@tokiwa.software>
+PKG_HOMEPAGE   := https://github.com/tokiwa-software/feeze
+PKG_LICENSE    := AGPL-3.0-only
+PKG_SUMMARY    := Interactive graphical thread and scheduling analysis tool using eBPF
+
+PKG_VERSION := $(shell cat $(FEEZE_REPO)/version.txt)
+PKG_FULLVERSION := $(PKG_VERSION)-$(PKG_RELEASE)
+
+UNAME_M  := $(shell uname -m)
+RPM_ARCH := $(UNAME_M)
+FILE_ARCH := $(shell uname -m | sed -e 's/x86_64/x86-64/' -e 's/aarch64/ARM aarch64/')
+DEB_ARCH := $(shell dpkg --print-architecture 2>/dev/null || \
+                    echo $(UNAME_M) | sed -e s/x86_64/amd64/ -e s/aarch64/arm64/)
+
+PKG_DIR   := $(BUILD_DIR)/pkg
+PKG_ROOT  := $(PKG_DIR)/root
+PKG_PREFIX := /usr/share/feeze
+PKG_SHARE := $(PKG_ROOT)$(PKG_PREFIX)
+PKG_TARDIR   := $(PKG_NAME)-$(PKG_VERSION)-$(DEB_ARCH)
+PKG_DEB_FILE := $(PKG_NAME)-$(PKG_VERSION)-$(DEB_ARCH).deb
+PKG_RPM_FILE := $(PKG_NAME)-$(PKG_VERSION)-$(DEB_ARCH).rpm
+
+
+PKG_BINARIES := $(BUILD_DIR)/bin/feeze          \
+                $(BUILD_DIR)/bin/feeze_desktop  \
+                $(BUILD_DIR)/bin/$(RECORDER_BIN)
+
+.PHONY: packages
+packages: pkg-tar pkg-deb pkg-rpm
+
+# -----------------------------------------------------------------------
+# Architecture guard: refuse to package a tree that was not built natively.
+# Catches "amd64 binary inside an arm64 package" mistake early.
+# -----------------------------------------------------------------------
+.PHONY: pkg-check-arch
+pkg-check-arch: $(BUILD_DIR)/bin/$(RECORDER_BIN)
+	@file $(BUILD_DIR)/bin/$(RECORDER_BIN) | grep -q "$(FILE_ARCH)" || { \
+	  echo "*** error: $(BUILD_DIR)/bin/$(RECORDER_BIN) is not a $(FILE_ARCH) binary." >&2; \
+	  echo "    packages must be built natively, see packaging.mk"  >&2; \
+	  file $(BUILD_DIR)/bin/$(RECORDER_BIN) >&2; \
+	  exit 1; }
+
+# -----------------------------------------------------------------------
+# Staging area.
+#
+# The code collects all Java application files into a single isolated folder usr/share/feeze,
+# since it is critical for the JVM to start that binaries, classes and jmod modules
+# are located together at the same level.
+# -----------------------------------------------------------------------
+.PHONY: pkg-stage
+pkg-stage: pkg-check-arch $(PKG_BINARIES) $(FEEZE_REPO)/packaging/feeze.desktop
+	rm -rf $(PKG_ROOT)
+	mkdir -p $(PKG_SHARE)/bin
+
+	install -m 755 $(BUILD_DIR)/bin/feeze         $(PKG_SHARE)/bin/feeze
+	install -m 755 $(BUILD_DIR)/bin/feeze_desktop $(PKG_SHARE)/bin/feeze_desktop
+	install -m 755 $(BUILD_DIR)/bin/$(RECORDER_BIN) $(PKG_SHARE)/bin/$(RECORDER_BIN)
+
+	install -m 755 $(FEEZE_REPO)/packaging/feeze-postinst $(PKG_SHARE)/bin/feeze-postinst
+
+	cp -a $(BUILD_CLASSES) $(PKG_SHARE)/classes
+	install -m 644 $(BUILD_DIR)/feeze.jmod $(PKG_SHARE)/feeze.jmod
+	install -m 644 $(BUILD_DIR)/icon.svg   $(PKG_SHARE)/icon.svg
+	install -m 644 $(FEEZE_REPO)/README.md $(PKG_SHARE)/README.md
+	install -m 644 $(FEEZE_REPO)/LICENSE   $(PKG_SHARE)/LICENSE
+	mkdir -p $(PKG_ROOT)/usr/bin
+	ln -sf ../share/feeze/bin/feeze              $(PKG_ROOT)/usr/bin/feeze
+	ln -sf ../share/feeze/bin/$(RECORDER_BIN)    $(PKG_ROOT)/usr/bin/$(RECORDER_BIN)
+	mkdir -p $(PKG_ROOT)/usr/share/applications
+	install -m 644 $(FEEZE_REPO)/packaging/feeze.desktop \
+	               $(PKG_ROOT)/usr/share/applications/feeze.desktop
+	mkdir -p $(PKG_ROOT)/usr/share/icons/hicolor/scalable/apps
+	install -m 644 $(FEEZE_REPO)/assets/logo.svg \
+	               $(PKG_ROOT)/usr/share/icons/hicolor/scalable/apps/feeze.svg
+	@echo " + Staged $(PKG_ROOT)"
+
+# -----------------------------------------------------------------------
+# Zero-install portable tarball
+# -----------------------------------------------------------------------
+.PHONY: pkg-tar
+pkg-tar: pkg-stage
+	rm -rf $(PKG_DIR)/$(PKG_TARDIR) $(PKG_TARDIR).tar.gz
+	mkdir -p $(PKG_DIR)/$(PKG_TARDIR)
+	cp -a $(PKG_SHARE)/. $(PKG_DIR)/$(PKG_TARDIR)/
+	tar czf $(PKG_TARDIR).tar.gz -C $(PKG_DIR) $(PKG_TARDIR)
+	@echo " + Created portable archive: $(PKG_TARDIR).tar.gz"
+
+# -----------------------------------------------------------------------
+# Debian package build (.deb) using raw dpkg-deb.
+# -----------------------------------------------------------------------
+.PHONY: pkg-deb
+pkg-deb: pkg-stage
+	rm -rf $(PKG_DIR)/deb $(PKG_DEB_FILE)
+	mkdir -p $(PKG_DIR)/deb/DEBIAN
+	cp -a $(PKG_ROOT)/. $(PKG_DIR)/deb/
+
+	mkdir -p $(PKG_DIR)/deb/usr/share/doc/$(PKG_NAME)
+	install -m 644 $(FEEZE_REPO)/LICENSE $(PKG_DIR)/deb/usr/share/doc/$(PKG_NAME)/copyright
+
+	sed -e 's|@NAME@|$(PKG_NAME)|g'                                  \
+	    -e 's|@VERSION@|$(PKG_FULLVERSION)|g'             \
+	    -e 's|@ARCH@|$(DEB_ARCH)|g'                                  \
+	    -e 's|@MAINTAINER@|$(PKG_MAINTAINER)|g'                      \
+	    -e 's|@HOMEPAGE@|$(PKG_HOMEPAGE)|g'                          \
+	    -e "s|@SIZE@|$$(du -ks $(PKG_DIR)/deb | cut -f1)|g"          \
+	    $(FEEZE_REPO)/packaging/control.in >$(PKG_DIR)/deb/DEBIAN/control
+		printf '#!/bin/sh\nset -e\n$(PKG_PREFIX)/bin/feeze-postinst\nexit 0\n' \
+	    >$(PKG_DIR)/deb/DEBIAN/postinst
+	chmod 755 $(PKG_DIR)/deb/DEBIAN/postinst
+	dpkg-deb --root-owner-group -Zzstd --build $(PKG_DIR)/deb $(PKG_DEB_FILE)
+	@echo " + $(PKG_DEB_FILE)"
+
+# -----------------------------------------------------------------------
+# rpm — AutoReqProv is disabled and Requires listed by hand: automatic soname
+# dependencies generated on a Debian host do not always map onto the provides
+# of the target distribution.
+# -----------------------------------------------------------------------
+.PHONY: pkg-rpm
+pkg-rpm: pkg-stage
+	rm -rf $(PKG_DIR)/rpm
+	mkdir -p $(PKG_DIR)/rpm/SPECS $(PKG_DIR)/rpm/BUILD $(PKG_DIR)/rpm/RPMS $(PKG_DIR)/rpm/SOURCES
+
+	sed -e 's|@NAME@|$(PKG_NAME)|g'             \
+	    -e 's|@VERSION@|$(PKG_VERSION)|g'       \
+	    -e 's|@RELEASE@|$(PKG_RELEASE)|g'       \
+	    -e 's|@SUMMARY@|$(PKG_SUMMARY)|g'       \
+	    -e 's|@LICENSE@|$(PKG_LICENSE)|g'       \
+	    -e 's|@HOMEPAGE@|$(PKG_HOMEPAGE)|g'     \
+		-e 's|@PREFIX@|$(PKG_PREFIX)|g'         \
+	    $(FEEZE_REPO)/packaging/feeze.spec.in >$(PKG_DIR)/rpm/SPECS/$(PKG_NAME).spec
+
+	rpmbuild -bb                                              \
+	  --define "_topdir $(abspath $(PKG_DIR)/rpm)"            \
+	  --define "pkgroot $(abspath $(PKG_ROOT))"               \
+	  --target $(RPM_ARCH)                                    \
+	  $(PKG_DIR)/rpm/SPECS/$(PKG_NAME).spec
+
+	# rpmbuild names the file by the canonical arch (x86_64/aarch64); rename it
+	# to the unified scheme. The architecture recorded inside the package is
+	# unaffected and must stay canonical, or dnf refuses to install it.
+	rm -f $(PKG_RPM_FILE)
+	cp $(PKG_DIR)/rpm/RPMS/$(RPM_ARCH)/$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE).$(RPM_ARCH).rpm \
+	   ./$(PKG_RPM_FILE)
+	@echo " + $(PKG_RPM_FILE)"
+
+.PHONY: pkg-clean
+pkg-clean:
+	rm -rf $(PKG_DIR)
+	rm -f $(PKG_NAME)-*.tar.gz $(PKG_NAME)-*.deb $(PKG_NAME)-*.rpm \

--- a/packaging.mk
+++ b/packaging.mk
@@ -82,8 +82,6 @@ pkg-stage: pkg-check-arch $(PKG_BINARIES) $(FEEZE_REPO)/packaging/feeze.desktop
 	install -m 755 $(BUILD_DIR)/bin/feeze_desktop $(PKG_SHARE)/bin/feeze_desktop
 	install -m 755 $(BUILD_DIR)/bin/$(RECORDER_BIN) $(PKG_SHARE)/bin/$(RECORDER_BIN)
 
-	install -m 755 $(FEEZE_REPO)/packaging/feeze-postinst $(PKG_SHARE)/bin/feeze-postinst
-
 	cp -a $(BUILD_CLASSES) $(PKG_SHARE)/classes
 	install -m 644 $(BUILD_DIR)/feeze.jmod $(PKG_SHARE)/feeze.jmod
 	install -m 644 $(BUILD_DIR)/icon.svg   $(PKG_SHARE)/icon.svg
@@ -113,7 +111,7 @@ $(PKG_TARDIR).tar.gz: pkg-stage
 # -----------------------------------------------------------------------
 # Debian package build (.deb) using raw dpkg-deb.
 # -----------------------------------------------------------------------
-$(PKG_DEB_FILE): pkg-stage
+$$(PKG_DEB_FILE): pkg-stage $(FEEZE_REPO)/packaging/feeze-postinst
 	rm -rf $(PKG_DIR)/deb $(PKG_DEB_FILE)
 	mkdir -p $(PKG_DIR)/deb/DEBIAN
 	cp -a $(PKG_ROOT)/. $(PKG_DIR)/deb/
@@ -128,9 +126,7 @@ $(PKG_DEB_FILE): pkg-stage
 	    -e 's|@HOMEPAGE@|$(PKG_HOMEPAGE)|g'                          \
 	    -e "s|@SIZE@|$$(du -ks $(PKG_DIR)/deb | cut -f1)|g"          \
 	    $(FEEZE_REPO)/packaging/control.in >$(PKG_DIR)/deb/DEBIAN/control
-		printf '#!/bin/sh\nset -e\n$(PKG_PREFIX)/bin/feeze-postinst\nexit 0\n' \
-	    >$(PKG_DIR)/deb/DEBIAN/postinst
-	chmod 755 $(PKG_DIR)/deb/DEBIAN/postinst
+		install -m 755 $(FEEZE_REPO)/packaging/feeze-postinst $(PKG_DIR)/deb/DEBIAN/postinst
 	dpkg-deb --root-owner-group -Zzstd --build $(PKG_DIR)/deb $(PKG_DEB_FILE)
 	@echo " + $(PKG_DEB_FILE)"
 
@@ -151,7 +147,6 @@ $(PKG_RPM_FILE): pkg-stage
 	    -e 's|@HOMEPAGE@|$(PKG_HOMEPAGE)|g'     \
 		-e 's|@PREFIX@|$(PKG_PREFIX)|g'         \
 	    $(FEEZE_REPO)/packaging/feeze.spec.in >$(PKG_DIR)/rpm/SPECS/$(PKG_NAME).spec
-
 	rpmbuild -bb                                              \
 	  --define "_topdir $(abspath $(PKG_DIR)/rpm)"            \
 	  --define "pkgroot $(abspath $(PKG_ROOT))"               \

--- a/packaging.mk
+++ b/packaging.mk
@@ -111,7 +111,7 @@ $(PKG_TARDIR).tar.gz: pkg-stage
 # -----------------------------------------------------------------------
 # Debian package build (.deb) using raw dpkg-deb.
 # -----------------------------------------------------------------------
-$$(PKG_DEB_FILE): pkg-stage $(FEEZE_REPO)/packaging/feeze-postinst
+$(PKG_DEB_FILE): pkg-stage $(FEEZE_REPO)/packaging/feeze-postinst
 	rm -rf $(PKG_DIR)/deb $(PKG_DEB_FILE)
 	mkdir -p $(PKG_DIR)/deb/DEBIAN
 	cp -a $(PKG_ROOT)/. $(PKG_DIR)/deb/

--- a/packaging.mk
+++ b/packaging.mk
@@ -1,4 +1,29 @@
-#Metadata
+# This file is part of the Feeze scheduling analysis tool.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+# -----------------------------------------------------------------------
+#
+#  Copyright (c) 2025, Tokiwa Software GmbH, Germany
+#
+#  Source of packaging Makefile
+#
+#  This is the Makefile for building feeze packages.
+#
+#
+# -----------------------------------------------------------------------
+
 PKG_NAME       := feeze
 PKG_RELEASE    := 1
 PKG_MAINTAINER := Tokiwa Software GmbH <siebert@tokiwa.software>

--- a/packaging.mk
+++ b/packaging.mk
@@ -52,8 +52,7 @@ PKG_BINARIES := $(BUILD_DIR)/bin/feeze          \
                 $(BUILD_DIR)/bin/feeze_desktop  \
                 $(BUILD_DIR)/bin/$(RECORDER_BIN)
 
-.PHONY: packages
-packages: pkg-tar pkg-deb pkg-rpm
+packages: $(PKG_TARDIR).tar.gz $(PKG_DEB_FILE) $(PKG_RPM_FILE)
 
 # -----------------------------------------------------------------------
 # Architecture guard: refuse to package a tree that was not built natively.
@@ -104,8 +103,7 @@ pkg-stage: pkg-check-arch $(PKG_BINARIES) $(FEEZE_REPO)/packaging/feeze.desktop
 # -----------------------------------------------------------------------
 # Zero-install portable tarball
 # -----------------------------------------------------------------------
-.PHONY: pkg-tar
-pkg-tar: pkg-stage
+$(PKG_TARDIR).tar.gz: pkg-stage
 	rm -rf $(PKG_DIR)/$(PKG_TARDIR) $(PKG_TARDIR).tar.gz
 	mkdir -p $(PKG_DIR)/$(PKG_TARDIR)
 	cp -a $(PKG_SHARE)/. $(PKG_DIR)/$(PKG_TARDIR)/
@@ -115,8 +113,7 @@ pkg-tar: pkg-stage
 # -----------------------------------------------------------------------
 # Debian package build (.deb) using raw dpkg-deb.
 # -----------------------------------------------------------------------
-.PHONY: pkg-deb
-pkg-deb: pkg-stage
+$(PKG_DEB_FILE): pkg-stage
 	rm -rf $(PKG_DIR)/deb $(PKG_DEB_FILE)
 	mkdir -p $(PKG_DIR)/deb/DEBIAN
 	cp -a $(PKG_ROOT)/. $(PKG_DIR)/deb/
@@ -142,8 +139,7 @@ pkg-deb: pkg-stage
 # dependencies generated on a Debian host do not always map onto the provides
 # of the target distribution.
 # -----------------------------------------------------------------------
-.PHONY: pkg-rpm
-pkg-rpm: pkg-stage
+$(PKG_RPM_FILE): pkg-stage
 	rm -rf $(PKG_DIR)/rpm
 	mkdir -p $(PKG_DIR)/rpm/SPECS $(PKG_DIR)/rpm/BUILD $(PKG_DIR)/rpm/RPMS $(PKG_DIR)/rpm/SOURCES
 

--- a/packaging.mk
+++ b/packaging.mk
@@ -21,7 +21,6 @@
 #
 #  This is the Makefile for building feeze packages.
 #
-#
 # -----------------------------------------------------------------------
 
 PKG_NAME       := feeze

--- a/packaging.mk
+++ b/packaging.mk
@@ -52,6 +52,9 @@ PKG_BINARIES := $(BUILD_DIR)/bin/feeze          \
                 $(BUILD_DIR)/bin/feeze_desktop  \
                 $(BUILD_DIR)/bin/$(RECORDER_BIN)
 
+# ELF e_machine as printed by readelf, used to verify the build was native.
+ELF_MACHINE := $(shell uname -m | sed -e 's/x86_64/X86-64/' -e 's/aarch64/AArch64/')
+
 packages: $(PKG_TARDIR).tar.gz $(PKG_DEB_FILE) $(PKG_RPM_FILE)
 
 # -----------------------------------------------------------------------
@@ -60,11 +63,8 @@ packages: $(PKG_TARDIR).tar.gz $(PKG_DEB_FILE) $(PKG_RPM_FILE)
 # -----------------------------------------------------------------------
 .PHONY: pkg-check-arch
 pkg-check-arch: $(BUILD_DIR)/bin/$(RECORDER_BIN)
-	@file $(BUILD_DIR)/bin/$(RECORDER_BIN) | grep -q "$(FILE_ARCH)" || { \
-	  echo "*** error: $(BUILD_DIR)/bin/$(RECORDER_BIN) is not a $(FILE_ARCH) binary." >&2; \
-	  echo "    packages must be built natively, see packaging.mk"  >&2; \
-	  file $(BUILD_DIR)/bin/$(RECORDER_BIN) >&2; \
-	  exit 1; }
+	@readelf -h $< | grep -q '$(ELF_MACHINE)' \
+	  || { echo "*** error: $< is not $(ELF_MACHINE), packages must be built natively" >&2; exit 1; }
 
 # -----------------------------------------------------------------------
 # Staging area.

--- a/packaging/control.in
+++ b/packaging/control.in
@@ -3,8 +3,7 @@ Version: @VERSION@
 Architecture: @ARCH@
 Maintainer: @MAINTAINER@
 Installed-Size: @SIZE@
-Depends: openjdk-25-jre, libgc1, libelf1, zlib1g,
-Requires: java-25-openjdk gc, elfutils-libelf, zlib1g
+Depends: openjdk-25-jre, libgc1, libelf1, zlib1g
 Section: utils
 Priority: optional
 Homepage: @HOMEPAGE@

--- a/packaging/control.in
+++ b/packaging/control.in
@@ -3,7 +3,7 @@ Version: @VERSION@
 Architecture: @ARCH@
 Maintainer: @MAINTAINER@
 Installed-Size: @SIZE@
-Depends: openjdk-25-jre, libgc1, libelf1, zlib1g
+Depends: openjdk-25-jre, libgc1, libelf1, zlib1g, libcap2-bin
 Section: utils
 Priority: optional
 Homepage: @HOMEPAGE@

--- a/packaging/control.in
+++ b/packaging/control.in
@@ -1,0 +1,12 @@
+Package: @NAME@
+Version: @VERSION@
+Architecture: @ARCH@
+Maintainer: @MAINTAINER@
+Installed-Size: @SIZE@
+Depends: openjdk-25-jre, libgc1, libelf1, zlib1g, bpftool
+Requires: java-25-openjdk gc, elfutils-libelf, zlib1g, bpftool
+Section: utils
+Priority: optional
+Homepage: @HOMEPAGE@
+Description: Feeze application
+ A desktop application built with Java.

--- a/packaging/control.in
+++ b/packaging/control.in
@@ -3,8 +3,8 @@ Version: @VERSION@
 Architecture: @ARCH@
 Maintainer: @MAINTAINER@
 Installed-Size: @SIZE@
-Depends: openjdk-25-jre, libgc1, libelf1, zlib1g, bpftool
-Requires: java-25-openjdk gc, elfutils-libelf, zlib1g, bpftool
+Depends: openjdk-25-jre, libgc1, libelf1, zlib1g,
+Requires: java-25-openjdk gc, elfutils-libelf, zlib1g
 Section: utils
 Priority: optional
 Homepage: @HOMEPAGE@

--- a/packaging/feeze-postinst
+++ b/packaging/feeze-postinst
@@ -22,7 +22,6 @@
 #
 #  This is the shared post-install hook used by both the deb and the rpm
 #
-#
 # -----------------------------------------------------------------------
 # Shared post-install hook, invoked from DEBIAN/postinst and from %post in the
 # spec so that deb and rpm cannot drift apart.

--- a/packaging/feeze-postinst
+++ b/packaging/feeze-postinst
@@ -32,12 +32,8 @@ REC=/usr/share/feeze/bin/feeze_recorder
 # Loading BPF programs and reading perf events needs CAP_BPF + CAP_PERFMON;
 # pinning maps needs CAP_SYS_RESOURCE on older kernels. Granting them here
 # avoids running the recorder as root. Failure is not fatal: sudo still works.
-if command -v setcap >/dev/null 2>&1 && [ -f "$REC" ]; then
-  setcap cap_bpf,cap_perfmon,cap_sys_resource+ep "$REC" 2>/dev/null \
-    || echo "feeze: could not set capabilities on $REC, run it as root" >&2
-else
-  echo "feeze: setcap unavailable, run the recorder as root" >&2
-fi
+setcap cap_bpf,cap_perfmon,cap_sys_resource+ep "$REC" \
+  || echo "feeze: could not set capabilities on $REC, run it as root" >&2
 
 if command -v update-desktop-database >/dev/null 2>&1; then
   update-desktop-database -q /usr/share/applications || true

--- a/packaging/feeze-postinst
+++ b/packaging/feeze-postinst
@@ -1,4 +1,29 @@
 #!/bin/sh
+# This file is part of the feeze scheduling analysis tool.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+# -----------------------------------------------------------------------
+#
+#  Copyright (c) 2025, Tokiwa Software GmbH, Germany
+#
+#  Source of feeze-postinst
+#
+#  This is the shared post-install hook used by both the deb and the rpm
+#
+#
+# -----------------------------------------------------------------------
 # Shared post-install hook, invoked from DEBIAN/postinst and from %post in the
 # spec so that deb and rpm cannot drift apart.
 set -eu

--- a/packaging/feeze-postinst
+++ b/packaging/feeze-postinst
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Shared post-install hook, invoked from DEBIAN/postinst and from %post in the
+# spec so that deb and rpm cannot drift apart.
+set -eu
+
+REC=/usr/share/feeze/bin/feeze_recorder
+
+# Loading BPF programs and reading perf events needs CAP_BPF + CAP_PERFMON;
+# pinning maps needs CAP_SYS_RESOURCE on older kernels. Granting them here
+# avoids running the recorder as root. Failure is not fatal: sudo still works.
+if command -v setcap >/dev/null 2>&1 && [ -f "$REC" ]; then
+  setcap cap_bpf,cap_perfmon,cap_sys_resource+ep "$REC" 2>/dev/null \
+    || echo "feeze: could not set capabilities on $REC, run it as root" >&2
+else
+  echo "feeze: setcap unavailable, run the recorder as root" >&2
+fi
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database -q /usr/share/applications || true
+fi
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor || true
+fi
+
+exit 0

--- a/packaging/feeze.desktop
+++ b/packaging/feeze.desktop
@@ -21,7 +21,6 @@
 #
 #  This is the XDG desktop entry installed by packaging.mk
 #
-#
 # -----------------------------------------------------------------------
 [Desktop Entry]
 Version=1.0

--- a/packaging/feeze.desktop
+++ b/packaging/feeze.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=feeze
+GenericName=Thread and scheduling analysis
+Comment=Interactive graphical thread and scheduling analysis tool using eBPF
+Exec=feeze
+Icon=feeze
+# The recorder may prompt for elevated privileges and prints diagnostics on
+# stderr, so keep a terminal attached.
+Terminal=true
+Categories=Development;Profiling;
+Keywords=eBPF;scheduler;threads;tracing;latency;
+# Matches the WM_CLASS that the JVM derives from the main class, so the window
+# is grouped with this launcher instead of appearing as a generic Java app.
+StartupWMClass=dev-feeze-Feeze

--- a/packaging/feeze.desktop
+++ b/packaging/feeze.desktop
@@ -1,3 +1,28 @@
+# This file is part of the Feeze scheduling analysis tool.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+# -----------------------------------------------------------------------
+#
+#  Copyright (c) 2025, Tokiwa Software GmbH, Germany
+#
+#  Source of feeze.desktop
+#
+#  This is the XDG desktop entry installed by packaging.mk
+#
+#
+# -----------------------------------------------------------------------
 [Desktop Entry]
 Version=1.0
 Type=Application

--- a/packaging/feeze.spec.in
+++ b/packaging/feeze.spec.in
@@ -58,8 +58,8 @@ per-thread run, ready and blocked state on a microsecond time axis, including
 wakeup arrows between threads.
 
 Recording requires a kernel with BTF support (/sys/kernel/btf/vmlinux) and the
-CAP_BPF and CAP_PERFMON capabilities. The package grants these to the recorder
-via setcap where available; otherwise run feeze_recorder as root.
+CAP_BPF and CAP_PERFMON capabilities, which the package grants to the recorder
+on installation. If that fails, run feeze_recorder as root.
 
 %prep
 # nothing to do, the tree is pre-staged
@@ -73,7 +73,12 @@ mkdir -p %{buildroot}
 cp -a %{pkgroot}/. %{buildroot}/
 
 %post
-@PREFIX@/bin/feeze-postinst || :
+setcap cap_bpf,cap_perfmon,cap_sys_resource+ep @PREFIX@/bin/feeze_recorder \
+  || echo "feeze: could not set capabilities, run the recorder as root" >&2
+command -v update-desktop-database >/dev/null 2>&1 && \
+  update-desktop-database -q /usr/share/applications || :
+command -v gtk-update-icon-cache >/dev/null 2>&1 && \
+  gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor || :
 
 %postun
 if [ $1 -eq 0 ] ; then

--- a/packaging/feeze.spec.in
+++ b/packaging/feeze.spec.in
@@ -50,7 +50,7 @@ Requires:       java-25-openjdk
 Requires:       gc
 Requires:       elfutils-libelf
 Requires:       zlib
-
+Requires:       libcap
 
 %description
 feeze records scheduling events with a BPF CO-RE program and displays

--- a/packaging/feeze.spec.in
+++ b/packaging/feeze.spec.in
@@ -21,7 +21,6 @@
 #
 #  This is the rpm spec template used by packaging.mk
 #
-#
 # -----------------------------------------------------------------------
 #
 # Nothing is compiled here: %install only copies the tree that packaging.mk

--- a/packaging/feeze.spec.in
+++ b/packaging/feeze.spec.in
@@ -1,0 +1,69 @@
+# Generated from packaging/feeze.spec.in by packaging.mk - do not edit build/.
+#
+# Nothing is compiled here: %install only copies the tree that packaging.mk
+# already staged, handed over via --define "pkgroot ...".
+
+# The payload consists of prebuilt binaries. Disable debuginfo extraction and
+# the brp-* post-install scripts, which are unavailable when rpmbuild runs on a
+# Debian or Ubuntu host.
+%global debug_package     %{nil}
+%global __os_install_post %{nil}
+%global _build_id_links   none
+
+Name:           @NAME@
+Version:        @VERSION@
+Release:        @RELEASE@
+Summary:        @SUMMARY@
+License:        @LICENSE@
+URL:            @HOMEPAGE@
+
+# Automatic soname dependency generation on a Debian host emits provides that
+# do not exist on Fedora or RHEL, so requirements are listed by hand.
+AutoReqProv:    no
+# A full JDK/JRE, not java-headless: the interface is Swing and needs
+# java.desktop. --enable-preview binds the class files to exactly Java 25.
+Requires:       java-25-openjdk
+Requires:       gc
+Requires:       elfutils-libelf
+Requires:       zlib
+Recommends:     bpftool
+
+%description
+feeze records scheduling events with a BPF CO-RE program and displays
+per-thread run, ready and blocked state on a microsecond time axis, including
+wakeup arrows between threads.
+
+Recording requires a kernel with BTF support (/sys/kernel/btf/vmlinux) and the
+CAP_BPF and CAP_PERFMON capabilities. The package grants these to the recorder
+via setcap where available; otherwise run feeze_recorder as root.
+
+%prep
+# nothing to do, the tree is pre-staged
+
+%build
+# nothing to do, the binaries are pre-built
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a %{pkgroot}/. %{buildroot}/
+
+%post
+@PREFIX@/bin/feeze-postinst || :
+
+%postun
+if [ $1 -eq 0 ] ; then
+  command -v update-desktop-database >/dev/null 2>&1 && \
+    update-desktop-database -q /usr/share/applications || :
+  command -v gtk-update-icon-cache >/dev/null 2>&1 && \
+    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor || :
+fi
+
+%files
+/usr/bin/feeze
+/usr/bin/feeze_recorder
+@PREFIX@
+/usr/share/applications/feeze.desktop
+/usr/share/icons/hicolor/scalable/apps/feeze.svg
+
+%changelog

--- a/packaging/feeze.spec.in
+++ b/packaging/feeze.spec.in
@@ -1,3 +1,28 @@
+# This file is part of the feeze scheduling analysis tool.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+
+# -----------------------------------------------------------------------
+#
+#  Copyright (c) 2025, Tokiwa Software GmbH, Germany
+#
+#  Source of feeze.spec.in
+#
+#  This is the rpm spec template used by packaging.mk
+#
+#
+# -----------------------------------------------------------------------
 # Generated from packaging/feeze.spec.in by packaging.mk - do not edit build/.
 #
 # Nothing is compiled here: %install only copies the tree that packaging.mk
@@ -6,6 +31,7 @@
 # The payload consists of prebuilt binaries. Disable debuginfo extraction and
 # the brp-* post-install scripts, which are unavailable when rpmbuild runs on a
 # Debian or Ubuntu host.
+
 %global debug_package     %{nil}
 %global __os_install_post %{nil}
 %global _build_id_links   none
@@ -26,7 +52,7 @@ Requires:       java-25-openjdk
 Requires:       gc
 Requires:       elfutils-libelf
 Requires:       zlib
-Recommends:     bpftool
+
 
 %description
 feeze records scheduling events with a BPF CO-RE program and displays

--- a/packaging/feeze.spec.in
+++ b/packaging/feeze.spec.in
@@ -23,7 +23,6 @@
 #
 #
 # -----------------------------------------------------------------------
-# Generated from packaging/feeze.spec.in by packaging.mk - do not edit build/.
 #
 # Nothing is compiled here: %install only copies the tree that packaging.mk
 # already staged, handed over via --define "pkgroot ...".


### PR DESCRIPTION
Adds packaging.mk , the metadata templates under packaging/, and .github/workflows/package.yml. 
All packaging logic lives in the Makefile; 
the workflow only provides the toolchain and calls it.

**Native runners per architecture**
Everything installs under /usr/share/feeze with relative symlinks in /usr/bin, since bin/feeze derives FEEZE_HOME from readlink -f "$0" and needs classes/ and feeze.jmod as siblings.

**Known limitation:** the workflow still patches the hardcoded vmlinux.h/include/x86_64/ path. The proper fix is maybe to parametrise both in the Makefile — I would prefer to do it that separately to keep this PR reviewable. 

The _built artifacts_ are available in my fork under the packages-ci branch, in the release tags.


**Use of AI assistance:** I used Claude to draft the initial structure of packaging.mk, the workflow and the metadata templates, then reviewed and rewrote them line by line. Several suggestions were wrong and were caught in testing.

I need feedback on whether I’ve understood the concept of task correctly, and whether any changes to the workflow might be needed, etc.

Thank you very much for your attention ;)