### PR TITLE
gui: Make ^Q and ^W work in control frame even some inner component has the focus

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -145,6 +145,10 @@ The following key-combination may be used as shortcuts:
 
 * <kbd>Alt</kbd>+<kbd>D</kbd> for `show data` button
 
+* <kbd>Ctrl</kbd>+<kbd>W</kbd> close window and quit feeze GUI
+
+* <kbd>Ctrl</kbd>+<kbd>Q</kbd> quit feeze GUI
+
 ## Scheduling Data Window
 
 The scheduling data window looks like this:
@@ -312,7 +316,7 @@ The following key-combination may be used as shortcuts:
 
 * <kbd>Ctrl</kbd>+<kbd>W</kbd> close window
 
-* <kbd>Ctrl</kbd>+<kbd>Q</kbd> quite feeze GUI
+* <kbd>Ctrl</kbd>+<kbd>Q</kbd> quit feeze GUI
 
 Have fun!
 

--- a/src/java/dev/feeze/ControlFrame.java
+++ b/src/java/dev/feeze/ControlFrame.java
@@ -341,7 +341,8 @@ public class ControlFrame extends JFrame
             }
           });
         setFocusable(true);
-        addKeyListener(new KeyListener()
+
+        var kl = new KeyListener()
           {
             @Override public void keyPressed(KeyEvent key) { }
             @Override public void keyReleased(KeyEvent key) { }
@@ -359,7 +360,16 @@ public class ControlFrame extends JFrame
                   System.out.println("typed: "+key.getKeyCode()+" "+key.getExtendedKeyCode()+" "+key.getKeyChar()+" "+((int)key.getKeyChar())+" w:"+('w'-0x90));
                 }
             }
-          });
+          };
+        addKeyListener(kl);
+        _startRecorder.addKeyListener(kl);
+        _record.addKeyListener(kl);
+        _showData.addKeyListener(kl);
+        _fuzionHomeDir.addKeyListener(kl);
+        _sharedMemName.addKeyListener(kl);
+        _sharedMemSize.addKeyListener(kl);
+        _recorderOutput.addKeyListener(kl);
+
         setVisible(true);
 
         var _listener = new ControlListener(this);

--- a/src/java/dev/feeze/FeezeDataFrame.java
+++ b/src/java/dev/feeze/FeezeDataFrame.java
@@ -95,7 +95,8 @@ public class FeezeDataFrame extends JFrame
             }
           });
         setFocusable(true);
-        addKeyListener(new KeyListener()
+
+        var kl = new KeyListener()
           {
             @Override public void keyPressed(KeyEvent key) { }
             @Override public void keyReleased(KeyEvent key) { }
@@ -113,7 +114,12 @@ public class FeezeDataFrame extends JFrame
                   System.out.println("typed: "+key.getKeyCode()+" "+key.getExtendedKeyCode()+" "+key.getKeyChar()+" "+((int)key.getKeyChar())+" w:"+('w'-0x90));
                 }
             }
-          });
+          };
+        addKeyListener(kl);
+        b1.addKeyListener(kl);
+        b2.addKeyListener(kl);
+        b3.addKeyListener(kl);
+        b4.addKeyListener(kl);
 
         setVisible(true);
         var ignore = Feeze._openDataFrames_.incrementAndGet();

--- a/web/content/doc/pages/manual.html
+++ b/web/content/doc/pages/manual.html
@@ -113,6 +113,9 @@ button</p></li>
 button</p></li>
 <li><p><kbd>Alt</kbd>+<kbd>D</kbd> for <code>show data</code>
 button</p></li>
+<li><p><kbd>Ctrl</kbd>+<kbd>W</kbd> close window and quit feeze
+GUI</p></li>
+<li><p><kbd>Ctrl</kbd>+<kbd>Q</kbd> quit feeze GUI</p></li>
 </ul>
 <h2 id="scheduling-data-window">Scheduling Data Window</h2>
 <p>The scheduling data window looks like this:</p>
@@ -250,7 +253,7 @@ Window Keyboard shortcuts</h3>
 <li><p><kbd>Alt</kbd>+<kbd>Z</kbd> zoom in one step</p></li>
 <li><p><kbd>Alt</kbd>+<kbd>O</kbd> zoom out one step</p></li>
 <li><p><kbd>Ctrl</kbd>+<kbd>W</kbd> close window</p></li>
-<li><p><kbd>Ctrl</kbd>+<kbd>Q</kbd> quite feeze GUI</p></li>
+<li><p><kbd>Ctrl</kbd>+<kbd>Q</kbd> quit feeze GUI</p></li>
 </ul>
 <p>Have fun!</p>
 <!--  LocalWords:  img src feeze eBPF zxf dev OpenJDK libgc Boehm Demers GC NYI Weiser's Fuzion recoder sudo fuzion msg fuzion's Xwaylend firefox wakesup Ctrl  -->


### PR DESCRIPTION
Adding key listeners to all fields does the trick.  This was also a problem for the data frame if the buttons were used.

Fix #108.

