### PR TITLE
gui: Open data frame using default size

### DIFF
--- a/src/java/dev/flang/swing/Panorama.java
+++ b/src/java/dev/flang/swing/Panorama.java
@@ -401,7 +401,10 @@ public abstract class Panorama extends JPanel
   public JScrollPane scroller(int w, int h)
   {
     var res = new JScrollPane(this);
-    res.setPreferredSize(new Dimension(w, h));
+    if (w > 0 && h > 0)
+      {
+        res.setPreferredSize(new Dimension(w, h));
+      }
 
     // increment used for arrow buttons and mouse wheel.
     //


### PR DESCRIPTION
This used to be opened using width 0 and height depending on the number of processes.  Now, this uses the default which seems more reasonable (full screen width and about 1/3 of screen height on my machine).

fix #90.
