### PR TITLE
doc: single installation guide in doc/Manual.md

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -150,6 +150,7 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with:
           pattern: packages-linux-*
@@ -189,5 +190,6 @@ jobs:
           prerelease: ${{ steps.tag.outputs.pre }}
           makeLatest: ${{ steps.tag.outputs.latest }}
           artifacts: artifacts/*
+          bodyFile: packaging/release-body.md
           generateReleaseNotes: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ it is also a goal to help to improve general throughput.
 A picture says more than a thousand words, so let's start with a screenshot of a
 trace taken while a graphical Java application is running using wayland:
 
-<img src="doc/images/scheduing_data_window.png" alt="sample scheduling data window" width="1105" />
+<img src="doc/images/scheduling_data_window.png" alt="sample scheduling data window" width="1105" />
 
 What we see on the left is a list of all threads group by users (`fridi` is the
 user name here), processes and threads. The top shows the time axis in µsec
@@ -63,13 +63,23 @@ feeze (third-person singular simple present feezes, present participle feezing, 
 
 A nice looking cake shop in Japan: [フィーゼ](https://nasuguru.com/feeze/).
 
+## Installation
+
+Releases are published under
+[feeze releases](https://github.com/tokiwa-software/feeze/releases) as `.deb`,
+`.rpm` and `.tar.gz` for `amd64` and `arm64`.
+
+For installation instructions, required dependencies and removal, see
+[Download and Installation](doc/Manual.md#download-and-installation) in the
+feeze user manual.
+
 ## Building
 
 ### Requirements
 
 * OpenJDK version 25 or later, the Java environment used for the GUI
 
-* `libgc1.so` (e.g. package `libgc` on Ubuntu, `libgc1` on Debian, `gc` on Arch)
+* `libgc1.so` (e.g. package `libgc1` on Ubuntu or Debian, `gc` on Arch)
   The Boehm-Demers-Weiser's GC that is currently used by Fuzion until an exact GC is available
 
 * bpftool for the currently running kernel

--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -11,22 +11,52 @@ Feeze is an interactive graphical thread and scheduling analysis tool using eBPF
 Downloadable releases will be published on GitHub under
 [feeze releases](https://github.com/tokiwa-software/feeze/releases).
 
+| file                        | intended for                           |
+|-----------------------------|----------------------------------------|
+| `feeze-VERSION-ARCH.deb`    | Debian, Ubuntu and derivatives         |
+| `feeze-VERSION-ARCH.rpm`    | Fedora, RHEL, openSUSE and derivatives |
+| `feeze-VERSION-ARCH.tar.gz` | any other distribution, no root needed |
+
+`VERSION` is the feeze version and `ARCH` is `amd64` or `arm64`. If unsure which
+one you need, use `dpkg --print-architecture`, or `uname -m` where `x86_64`
+means `amd64` and `aarch64` means `arm64`.
+
+### Installation from deb package
+
+On Debian, Ubuntu and derivatives, install the package using
+
+    > sudo apt install ./feeze-0.001dev-amd64.deb
+
+Keep the leading `./` and use `apt`, not `dpkg -i`: `apt` resolves the
+dependencies declared by the package, `dpkg` does not and would leave feeze
+unconfigured.
+
+### Installation from rpm package
+
+On Fedora and RHEL, install the package using
+
+    > sudo dnf install ./feeze-0.001dev-amd64.rpm
+
+on openSUSE, use
+
+    > sudo zypper install ./feeze-0.001dev-amd64.rpm
+
 ### Installation from tarball
 
 Installing feeze from a tarball gives you most control over where feeze will get
 installed. You will need to unpack the archive using
 
-    # tar zxf feeze_VERSION_TARGET.tar.gz
+    # tar zxf feeze-VERSION-ARCH.tar.gz
 
-where `VERSION` is the feeze version and `TARGET` is the
-target Linux version it was built for. For version `0.001dev` built
-for `Ubuntu_24`, you will have to use
+where `VERSION` is the feeze version and `ARCH` is the
+architecture it was built for. For version `0.001dev` built
+for `amd64`, you will have to use
 
-    # tar zxf feeze_0.001dev_Ubuntu_24.tar.gz
+    # tar zxf feeze-0.001dev-amd64.tar.gz
 
-The result will be a directory with a name like `feeze_VERSION_TARGET`, so in
-our example of version `0.001dev` build for `Ubuntu_24` the directory name will
-be `feeze_0.001dev_Ubuntu_24`.
+The result will be a directory with a name like `feeze-VERSION-ARCH`, so in
+our example of version `0.001dev` build for `amd64` the directory name will
+be `feeze-0.001dev-amd64`.
 
 ### Required Dependencies
 
@@ -69,7 +99,7 @@ To run feeze, you will need to install
 
 To start the feeze GUI, run the script `feeze` in the `bin` directory of the installation, e.g., using
 
-    # ./feeze_0.001dev_Ubuntu_24/bin/feeze
+    # ./feeze-0.001dev-amd64/bin/feeze
 
 ## Feeze Control Window
 

--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -86,11 +86,11 @@ To run feeze, you will need to install
   To install libgc.so, on Ubuntu, do
 
       > sudo apt update
-      > sudo apt install libgc
+      > sudo apt install libgc1
 
   on Fedora, do
 
-      > sudo dnf install libgc
+      > sudo dnf install gc
 
   This is the Boehm-Demers-Weiser's GC that is currently used by Fuzion until an
   exact GC is available.

--- a/packaging/release-body.md
+++ b/packaging/release-body.md
@@ -1,0 +1,9 @@
+Packages for `amd64` and `arm64`:
+
+* `feeze-VERSION-ARCH.deb` — Debian, Ubuntu and derivatives
+* `feeze-VERSION-ARCH.rpm` — Fedora, RHEL, openSUSE and derivatives
+* `feeze-VERSION-ARCH.tar.gz` — any other distribution, no root needed
+
+For installation instructions, required dependencies and removal, see
+[Download and Installation](https://github.com/tokiwa-software/feeze/blob/main/doc/Manual.md#download-and-installation)
+in the feeze user manual.

--- a/web/content/doc/pages/manual.html
+++ b/web/content/doc/pages/manual.html
@@ -7,19 +7,59 @@ using eBPF.</p>
 <p>Downloadable releases will be published on GitHub under <a
 href="https://github.com/tokiwa-software/feeze/releases">feeze
 releases</a>.</p>
+<table>
+<thead>
+<tr>
+<th>file</th>
+<th>intended for</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>feeze-VERSION-ARCH.deb</code></td>
+<td>Debian, Ubuntu and derivatives</td>
+</tr>
+<tr>
+<td><code>feeze-VERSION-ARCH.rpm</code></td>
+<td>Fedora, RHEL, openSUSE and derivatives</td>
+</tr>
+<tr>
+<td><code>feeze-VERSION-ARCH.tar.gz</code></td>
+<td>any other distribution, no root needed</td>
+</tr>
+</tbody>
+</table>
+<p><code>VERSION</code> is the feeze version and <code>ARCH</code> is
+<code>amd64</code> or <code>arm64</code>. If unsure which one you need,
+use <code>dpkg --print-architecture</code>, or <code>uname -m</code>
+where <code>x86_64</code> means <code>amd64</code> and
+<code>aarch64</code> means <code>arm64</code>.</p>
+<h3 id="installation-from-deb-package">Installation from deb
+package</h3>
+<p>On Debian, Ubuntu and derivatives, install the package using</p>
+<pre><code>&gt; sudo apt install ./feeze-0.001dev-amd64.deb</code></pre>
+<p>Keep the leading <code>./</code> and use <code>apt</code>, not
+<code>dpkg -i</code>: <code>apt</code> resolves the dependencies
+declared by the package, <code>dpkg</code> does not and would leave
+feeze unconfigured.</p>
+<h3 id="installation-from-rpm-package">Installation from rpm
+package</h3>
+<p>On Fedora and RHEL, install the package using</p>
+<pre><code>&gt; sudo dnf install ./feeze-0.001dev-amd64.rpm</code></pre>
+<p>on openSUSE, use</p>
+<pre><code>&gt; sudo zypper install ./feeze-0.001dev-amd64.rpm</code></pre>
 <h3 id="installation-from-tarball">Installation from tarball</h3>
 <p>Installing feeze from a tarball gives you most control over where
 feeze will get installed. You will need to unpack the archive using</p>
-<pre><code># tar zxf feeze_VERSION_TARGET.tar.gz</code></pre>
-<p>where <code>VERSION</code> is the feeze version and
-<code>TARGET</code> is the target Linux version it was built for. For
-version <code>0.001dev</code> built for <code>Ubuntu_24</code>, you will
-have to use</p>
-<pre><code># tar zxf feeze_0.001dev_Ubuntu_24.tar.gz</code></pre>
+<pre><code># tar zxf feeze-VERSION-ARCH.tar.gz</code></pre>
+<p>where <code>VERSION</code> is the feeze version and <code>ARCH</code>
+is the architecture it was built for. For version <code>0.001dev</code>
+built for <code>amd64</code>, you will have to use</p>
+<pre><code># tar zxf feeze-0.001dev-amd64.tar.gz</code></pre>
 <p>The result will be a directory with a name like
-<code>feeze_VERSION_TARGET</code>, so in our example of version
-<code>0.001dev</code> build for <code>Ubuntu_24</code> the directory
-name will be <code>feeze_0.001dev_Ubuntu_24</code>.</p>
+<code>feeze-VERSION-ARCH</code>, so in our example of version
+<code>0.001dev</code> build for <code>amd64</code> the directory name
+will be <code>feeze-0.001dev-amd64</code>.</p>
 <h3 id="required-dependencies">Required Dependencies</h3>
 <p>To run feeze, you will need to install</p>
 <ul>
@@ -45,7 +85,7 @@ until an exact GC is available.</p></li>
 <h3 id="running">Running</h3>
 <p>To start the feeze GUI, run the script <code>feeze</code> in the
 <code>bin</code> directory of the installation, e.g., using</p>
-<pre><code># ./feeze_0.001dev_Ubuntu_24/bin/feeze</code></pre>
+<pre><code># ./feeze-0.001dev-amd64/bin/feeze</code></pre>
 <h2 id="feeze-control-window">Feeze Control Window</h2>
 <p>Once started, the feeze control window is opened.</p>
 <p><img src="images/control_window.png" alt="sample control window" width="638" /></p>

--- a/web/content/pages/downloads.html
+++ b/web/content/pages/downloads.html
@@ -3,57 +3,19 @@
 <h2>Feeze Releases</h2>
 <p>
   Downloadable releases will be published on github
-  under <a href="https://github.com/tokiwa-software/feeze/releases"
-  target="_blank">feeze releases</a>.
+  under <a href="https://github.com/tokiwa-software/feeze/releases" target="_blank">feeze releases</a>, as
+  <code>.deb</code>, <code>.rpm</code>
+  and <code>.tar.gz</code> packages for <code>amd64</code>
+  and <code>arm64</code>.
 </p>
 <h2>Installation</h2>
-<h3>From tarball</h3>
 <p>
-  Installing Feeze from a tarball gives you most control over where feeze will
-  get installed. You will need to unpack the archive using
-  <pre>
-    # tar zxf feeze_VERSION_TARGET.tar.gz
-  </pre>
-  where <code>VERSION</code> is the feeze version and <code>TARGET</code> is the
-  target Linux version it was built for. For version <code>0.001dev</code> build
-  for <code>Ubuntu_24</code>, you will have to use
-  <pre>
-    # tar zxf feeze_0.001dev_Ubuntu_24.tar.gz
-  </pre>
-  The result will be a directory with a name
-  like <code>feeze_VERSION_TARGET</code>, so in our example of
-  version <code>0.001dev</code> build for <code>Ubuntu_24</code> the directory
-  name will be <code>feeze_0.001dev_Ubuntu_24</code>.
+  For installation instructions, required dependencies, running and removal,
+  see <a href="doc/manual.html#download-and-installation">Download and
+    Installation</a> in the feeze user manual.
 </p>
-<h3>Required Dependencies</h3>
-<p>
-  To run feeze, you will need to install
-  <ul>
-    <li><p>OpenJDK version 25 or later</p>
-      <p>the Java environment used for the GUI, and </p>
-    </li>
-    <li>
-      <p>libgc1.so</p>
-      <p>The Boehm-Demers-Weiser's GC that is currently used by Fuzion until an
-      exact GC is available.</p>
-    </li>
-  </ul>
-</p>
-<h3>Running</h3>
-<p>
-  To start feeze, run the script <code>feeze</code> in the <code>bin</code> directory of the installation, e.g., using
-  <pre>
-    # ./feeze_0.001dev_Ubuntu_24/bin/feeze
-  </pre>
-</p>
-<p>
-  For detailed instructions, refer to the <a href="doc">documentation</a>.
-</p>
-
 <p>
   Have fun!
 </p>
-<p></p>
-
 <!--  LocalWords:  Feeze github feeze OpenJDK Boehm Demers Weiser's GC Fuzion
  -->


### PR DESCRIPTION
This PR makes `doc/Manual.md` the single place for installation instructions:

- deb, rpm and tarball installation, correct dependency names per
  distribution, capabilities and removal
- `README.md`, `downloads.html` and the GitHub release body now link to that
  section instead of repeating it
- release body is added via `bodyFile`; the release job now needs a checkout